### PR TITLE
Error using demo configuration file

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -24,7 +24,7 @@
 # Show config from "[show]" although show has no options at present.
 ##procs = show, db:lite
 
-procs = show # just print
+procs = show ; just print
 
 # Time interval for sending recceiver advertisments
 #announceInterval = 15.0


### PR DESCRIPTION
When I try to use this demo configuration I get the following error:

```
  File "/usr/bin/twistd", line 14, in <module>
    run()
  File "/usr/lib/python2.7/dist-packages/twisted/scripts/twistd.py", line 27, in run
    app.run(runApp, ServerOptions)
  File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 642, in run
    runApp(config)
  File "/usr/lib/python2.7/dist-packages/twisted/scripts/twistd.py", line 23, in runApp
    _SomeApplicationRunner(config).run()
  File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 376, in run
    self.application = self.createOrGetApplication()
  File "/usr/lib/python2.7/dist-packages/twisted/application/app.py", line 436, in createOrGetApplication
    ser = plg.makeService(self.config.subOptions)
  File "/home/devuser/iocplayground/recsync-package/recsync/server/recceiver/application.py", line 103, in makeService
    ctrl = ProcessorController(cfile=opts['config'])
  File "/home/devuser/iocplayground/recsync-package/recsync/server/recceiver/processors.py", line 80, in __init__
    plug = plugs[plugname]
  KeyError: 'show # just print'
```

The documentation for [ConfigParser](https://docs.python.org/2/library/configparser.html) states that only semi-colons are supported for in-line comments.
