### PR TITLE
System configuration clobbers local configuration

### DIFF
--- a/server/recceiver/processors.py
+++ b/server/recceiver/processors.py
@@ -49,12 +49,12 @@ class ProcessorController(service.MultiService):
     def __init__(self, cfile=None):
         service.MultiService.__init__(self)
         parser = Parser(self.defaults)
-        
+
+        read = parser.read(map(expanduser, self.paths))
+
         if cfile:
             parser.readfp(open(cfile,'r'))
 
-        read = parser.read(map(expanduser, self.paths))
-        
         if not cfile and len(read)==0:
             # no user configuration given so load some defaults
             parser.add_section('recceiver')


### PR DESCRIPTION
The configuration specified on the command line with -f option get overridden by the global configuration.
