### PR TITLE
Fix optional dependency on Channel Finder client library.

### DIFF
--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -6,7 +6,6 @@ from zope.interface import implements
 from twisted.internet import defer
 from twisted.application import service
 from twisted.enterprise import adbapi as db
-from channelfinder import ChannelFinderClient
 import interfaces
 import datetime
 
@@ -36,6 +35,7 @@ class CFProcessor(service.Service):
         service.Service.startService(self)
         self.running = 1
         print "CF_START"
+        from channelfinder import ChannelFinderClient
         # Using the default python cf-client.
         # The usr, username, and password are provided by the channelfinder._conf module.
         self.client = ChannelFinderClient()

--- a/server/twisted/plugins/recceiver_plugin.py
+++ b/server/twisted/plugins/recceiver_plugin.py
@@ -2,9 +2,10 @@
 
 from recceiver.application import Maker
 
-from recceiver import processors, dbstore
+from recceiver import processors, dbstore, cfstore
 
 serviceMaker = Maker()
 
 showfactory = processors.ProcessorFactory('show', processors.ShowProcessor)
 dbfactory = processors.ProcessorFactory('db',  dbstore.DBProcessor)
+cffactory = processors.ProcessorFactory('cf', cfstore.CFProcessor)

--- a/server/twisted/plugins/recceiver_plugin.py
+++ b/server/twisted/plugins/recceiver_plugin.py
@@ -8,11 +8,3 @@ serviceMaker = Maker()
 
 showfactory = processors.ProcessorFactory('show', processors.ShowProcessor)
 dbfactory = processors.ProcessorFactory('db',  dbstore.DBProcessor)
-
-try:
-    from channelfinder import ChannelFinderClient
-except ImportError:
-    pass
-else:
-    from recceiver import cfstore
-    cffactory = processors.ProcessorFactory('cf', cfstore.CFProcessor)


### PR DESCRIPTION
I initially used the same approach as you to make the cfstore plugin optional, but I ran into a problem with the Twisted Plugin cache.

If you install recceiver WITHOUT the CF client library installed the Twisted plugin cache will be refreshed at the time of installation and the cfstore plugin will not be available. Then if you install the CF client library and try to use the cfstore plugin it will not be available without manually triggering a refresh of the Twisted plugin cache.  

As a result, I implemented an alternative approach which allows the cfstore plugin to be properly cached at the time of installation, but does not require the CF client to be installed until the plugin is actually started.
