### PR TITLE
BLD: use setuptools instead of distutils

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -4,7 +4,8 @@ Priority: extra
 Maintainer: Dylan Maxwell <maxwelld@frib.msu.edu>
 Build-Depends: debhelper (>= 9), dh-python, epics-debhelper (>= 8.14~),
                epics-dev,
-               python-all-dev, python-twisted-core,
+               python-all-dev, python-setuptools,
+               python-twisted-core,
 Standards-Version: 3.9.6
 XS-Python-Version: >= 2.7
 Homepage: https://github.com/ChannelFinder/recsync

--- a/server/setup.py
+++ b/server/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from distutils.core import setup
+from setuptools import setup
 
 setup(
   name="recceiver",


### PR DESCRIPTION
A modest modernization. For the moment, permits a bit of development ease:

```shell
python setup.py develop --user
```

More benefits to come in follow-up PRs...