### PR TITLE
Add missing dependency on lsb-base

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libdevel
 Priority: extra
 Maintainer: Dylan Maxwell <maxwelld@frib.msu.edu>
 Build-Depends: debhelper (>= 9), dh-python, epics-debhelper (>= 8.14~),
-               epics-dev,
+               epics-dev, lsb-base,
                python-all-dev, python-setuptools,
                python-twisted-core,
 Standards-Version: 3.9.6


### PR DESCRIPTION
The init script includes `/lib/lsb/init-functions` which is provided by `lsb-base`. This fixes a Lintian error.