### PR TITLE
Add lsb-base to depends on recceiver binary package

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -3,7 +3,7 @@ Section: libdevel
 Priority: extra
 Maintainer: Dylan Maxwell <maxwelld@frib.msu.edu>
 Build-Depends: debhelper (>= 9), dh-python, epics-debhelper (>= 8.14~),
-               epics-dev, lsb-base,
+               epics-dev,
                python-all-dev, python-setuptools,
                python-twisted-core,
 Standards-Version: 3.9.6
@@ -37,7 +37,7 @@ Package: recceiver
 Architecture: all
 Section: admin
 Depends: ${shlibs:Depends}, ${python:Depends}, ${misc:Depends},
-         adduser,
+         adduser, lsb-base,
 Suggests: epics-recsync-dev,
 XB-Python-Version: ${python:Versions}
 Description: recsync client


### PR DESCRIPTION
@mark0n 
I still see the 'init.d-script-needs-depends-on-lsb-base' lintian error on the latest build. I think the lsb-base package needs to be added as a runtime depends.