### PR TITLE
Record alias in CF

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -59,7 +59,7 @@ idkey = 42
 
 [cf]
 # cf-store application
-
+#alias = on
 # Debug output file location.
 # Produces no file when not defined.
 # debug_file_loc = /home/devuser/recsyncdata.txt

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -59,7 +59,7 @@ idkey = 42
 
 [cf]
 # cf-store application
-#alias = on
+alias = on
 # Debug output file location.
 # Produces no file when not defined.
 # debug_file_loc = /home/devuser/recsyncdata.txt

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -4,7 +4,7 @@
 [recceiver]
 
 # Logging detail level.  Use python logging level name.
-loglevel = DEBUG
+#loglevel = WARN
 
 # list of broadcast addresses.
 # default
@@ -27,7 +27,7 @@ loglevel = DEBUG
 # Show config from "[show]" although show has no options at present.
 ##procs = show, db:lite
 
-procs = show, cf ; just print
+procs = show ; just print
 
 # Time interval for sending recceiver advertisments
 #announceInterval = 15.0
@@ -59,7 +59,8 @@ idkey = 42
 
 [cf]
 # cf-store application
-alias = on
+# Uncomment line below to turn on the feature to add alias records to channelfinder
+# alias = on
 # Debug output file location.
 # Produces no file when not defined.
 # debug_file_loc = /home/devuser/recsyncdata.txt

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -4,7 +4,7 @@
 [recceiver]
 
 # Logging detail level.  Use python logging level name.
-#loglevel = WARN
+loglevel = DEBUG
 
 # list of broadcast addresses.
 # default
@@ -27,7 +27,7 @@
 # Show config from "[show]" although show has no options at present.
 ##procs = show, db:lite
 
-procs = show ; just print
+procs = show, cf ; just print
 
 # Time interval for sending recceiver advertisments
 #announceInterval = 15.0

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -233,8 +233,10 @@ def dict_to_file(dict, iocs, conf):
 
 def __updateCF__(client, pvInfo, delrec, channels_dict, iocs, conf, hostName, iocName, iocid, owner, iocTime):
     new = [info["pvName"] for rid, (info) in pvInfo.items()]
+
     if hostName is None or iocName is None:
         raise Exception('missing hostName or iocName')
+
     channels = []
     """A list of channels in channelfinder with the associated hostName and iocName"""
     old = client.findByArgs([('iocid', iocid)])
@@ -295,6 +297,7 @@ def __updateCF__(client, pvInfo, delrec, channels_dict, iocs, conf, hostName, io
                                                                ch[u'properties'])
                     channels.append(ch)
                     new.remove(ch[u'name'])
+
                     """In case, alias exist"""
                     if (conf.get('alias', 'default') == 'on'):
                         al = [info["aliases"] for rid, (info) in pvInfo.items() if info["pvName"] == ch and "aliases" in info ]
@@ -321,6 +324,7 @@ def __updateCF__(client, pvInfo, delrec, channels_dict, iocs, conf, hostName, io
     # now pvNames contains a list of pv's new on this host/ioc
     """A dictionary representing the current channelfinder information associated with the pvNames"""
     existingChannels = {}
+
     """
     The list of pv's is searched keeping in mind the limitations on the URL length
     The search is split into groups to ensure that the size does not exceed 600 characters
@@ -351,6 +355,7 @@ def __updateCF__(client, pvInfo, delrec, channels_dict, iocs, conf, hostName, io
         _log.debug("InfoProperties: " + str(infoProperties))
         if len(infoProperties) == 1:
             newProps = newProps + infoProperties[0]
+        _log.debug(newProps)
         aliasProperties = [info["aliases"] for rid, (info) in pvInfo.items() if info["pvName"] == pv and "aliases" in info ]
         _log.debug("aliasProperties: " + str(aliasProperties))
         if pv in existingChannels:


### PR DESCRIPTION
What is the change for?
->The changes are for adding alias records in CF. Currently, alias are not logged to the CF.

Will this affect everyone?
->No. This feature is optional to have. It can be set to on/off through demo.conf file using keyword 'alias'.

What does this new code change do?
-> For every record with an alias, the code creates a new 'alias record' in Channelfinder. 
For instance, if the below is the record from an IOC that has alias attached
record(longin, "$(P)li") {
  alias("$(P)lix1")
  alias("$(P)lix2")
  info("test", "testing")
}
then, two additional channels 'lix1' and 'lix2' will be created in CF with exactly same properties as their parent channel 'li'. The two alias channels 'lix1' and 'lix2' will have a property called 'alias' whose value is the parent channel name.

This is how they appear in channelFinder.
[{"name":"test:lix1","owner":"myself","properties":[{"name":"alias","owner":"cfstore","value":"test:li"},{"name":"hostName","owner":"cfstore","value":"develop-vmphy0"},{"name":"iocName","owner":"cfstore","value":"myioc"},{"name":"iocid","owner":"cfstore","value":"127.0.0.1:53430"},{"name":"pvStatus","owner":"cfstore","value":"Active"},{"name":"time","owner":"cfstore","value":"2018-11-26 16:32:14.902487"}],"tags":[]},


