### PR TITLE
Fix problem with client RIDs being reused when more then 65536 records

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,6 @@ dropin.cache
 *.log
 *.pid
 *.db
+client/configure/*.local
 
 *~

--- a/client/.ci/travis-build.sh
+++ b/client/.ci/travis-build.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+set -x -e
+
+export EPICS_HOST_ARCH=`sh $HOME/epics-base/startup/EpicsHostArch`
+
+make -j2
+
+[ "$TEST" = "YES" ] || exit 0
+
+lspci
+
+make tapfiles
+
+make -s test-results || find . -name '*.tap' -print0 | xargs -0 -n1 prove -e cat -f

--- a/client/.ci/travis-prepare.sh
+++ b/client/.ci/travis-prepare.sh
@@ -1,0 +1,66 @@
+#!/bin/sh
+set -e -x
+
+cat << EOF > configure/RELEASE
+EPICS_BASE=$HOME/epics-base
+EOF
+
+git clone --depth 10 --branch $BASE https://github.com/epics-base/epics-base.git $HOME/epics-base
+
+export EPICS_HOST_ARCH=`sh $HOME/epics-base/startup/EpicsHostArch`
+
+case "$STATIC" in
+static)
+    cat << EOF >> "$HOME/epics-base/configure/CONFIG_SITE"
+SHARED_LIBRARIES=NO
+STATIC_BUILD=YES
+EOF
+    ;;
+*) ;;
+esac
+
+case "$CMPLR" in
+clang)
+  echo "Host compiler is clang"
+  cat << EOF >> $HOME/epics-base/configure/os/CONFIG_SITE.Common.$EPICS_HOST_ARCH
+GNU         = NO
+CMPLR_CLASS = clang
+CC          = clang
+CCC         = clang++
+EOF
+  ;;
+*) echo "Host compiler is default";;
+esac
+
+# requires wine and g++-mingw-w64-i686
+if [ "$WINE" = "32" ]
+then
+  echo "Cross mingw32"
+  sed -i -e '/CMPLR_PREFIX/d' $HOME/epics-base/configure/os/CONFIG_SITE.linux-x86.win32-x86-mingw
+  cat << EOF >> $HOME/epics-base/configure/os/CONFIG_SITE.linux-x86.win32-x86-mingw
+CMPLR_PREFIX=i686-w64-mingw32-
+EOF
+  cat << EOF >> $HOME/epics-base/configure/CONFIG_SITE
+CROSS_COMPILER_TARGET_ARCHS+=win32-x86-mingw
+EOF
+fi
+
+# set RTEMS to eg. "4.9" or "4.10"
+if [ -n "$RTEMS" ]
+then
+  echo "Cross RTEMS${RTEMS} for pc386"
+  curl -L "https://github.com/mdavidsaver/rsb/releases/download/20171203-${RTEMS}/i386-rtems${RTEMS}-trusty-20171203-${RTEMS}.tar.bz2" \
+  | tar -C / -xmj
+
+  sed -i -e '/^RTEMS_VERSION/d' -e '/^RTEMS_BASE/d' $HOME/epics-base/configure/os/CONFIG_SITE.Common.RTEMS
+  cat << EOF >> $HOME/epics-base/configure/os/CONFIG_SITE.Common.RTEMS
+RTEMS_VERSION=$RTEMS
+RTEMS_BASE=$HOME/.rtems
+EOF
+  cat << EOF >> $HOME/epics-base/configure/CONFIG_SITE
+CROSS_COMPILER_TARGET_ARCHS += RTEMS-pc386-qemu
+EOF
+
+fi
+
+make -C "$HOME/epics-base" -j2

--- a/client/.travis.yml
+++ b/client/.travis.yml
@@ -1,0 +1,20 @@
+dist: trusty
+language: c
+compiler:
+  - gcc
+addons:
+  apt:
+    packages:
+    - libreadline6-dev
+    - libncurses5-dev
+    - perl
+    - clang
+env:
+ - BASE=7.0  STATIC=shared RTEMS=4.9 TEST=YES
+ - BASE=3.16 STATIC=shared TEST=YES
+ - BASE=3.16 STATIC=static RTEMS=4.9
+ - BASE=3.16 STATIC=shared CMPLR=clang RTEMS=4.10
+ - BASE=3.15 STATIC=shared
+ - BASE=3.14 STATIC=shared
+install: .ci/travis-prepare.sh
+script: .ci/travis-build.sh

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -179,7 +179,7 @@ ssize_t casterSendRA(caster_t* self, epicsUInt8 type, size_t rid, const char* rt
     epicsUInt32 blen = sizeof(buf.c_add);
     size_t lt=rtype ? strlen(rtype) : 0, ln=strlen(rname);
 
-    buf.c_add.rid = htons(rid);
+    buf.c_add.rid = htonl(rid);
     buf.c_add.rtype = type;
     buf.c_add.rtlen = lt;
     buf.c_add.rnlen = htons(ln);
@@ -229,7 +229,7 @@ int casterSendInfo(caster_t *self, ssize_t rid, const char* name, const char* va
     if(rid<0)
         return -1;
 
-    buf.c_info.rid = htons(rid);
+    buf.c_info.rid = htonl(rid);
     buf.c_info.klen = ln;
     buf.c_info.reserved = 0;
     buf.c_info.vlen = htons(lv);

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -187,7 +187,7 @@ int shWaitFor(shSocket *s, int op, int flags)
 
     if(ret<0) {
             return ret;
-    } else if(ret==0 || FD_ISSET(s->wakeup, &rset)) {
+    } else if(ret==0 || (s->wakeup!=INVALID_SOCKET && FD_ISSET(s->wakeup, &rset))) {
         SOCKERRNOSET(SOCK_ETIMEDOUT);
         return -1;
     } else { /* ret>0 && !FD_ISSET(wakeup, &rset) */

--- a/client/castApp/src/testtcp.c
+++ b/client/castApp/src/testtcp.c
@@ -222,7 +222,7 @@ static void testCB(void)
 
     testOk1(shRecvExact(&sock[1], &buf.bytes, sizeof(buf.c_add), 0)==sizeof(buf.c_add));
 
-    testOk1(buf.c_add.rid==htons(42));
+    testOk1(buf.c_add.rid==htonl(42));
     testOk1(buf.c_add.rtype==0);
     testOk1(buf.c_add.rtlen==5);
     testOk1(buf.c_add.rnlen==htons(5));
@@ -242,7 +242,7 @@ static void testCB(void)
 
     testOk1(shRecvExact(&sock[1], &buf.bytes, sizeof(buf.c_info), 0)==sizeof(buf.c_info));
 
-    testOk1(buf.c_info.rid==htons(42));
+    testOk1(buf.c_info.rid==htonl(42));
     testOk1(buf.c_info.klen==3);
     testOk1(buf.c_info.vlen==htons(3));
 

--- a/client/configure/RELEASE
+++ b/client/configure/RELEASE
@@ -19,11 +19,15 @@
 # Build settings that are NOT module paths should appear in a
 # CONFIG_SITE file.
 
-TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
+#TEMPLATE_TOP=$(EPICS_BASE)/templates/makeBaseApp/top
 
 # EPICS_BASE usually appears last so other apps can override stuff:
-EPICS_BASE=/usr/lib/epics
+#EPICS_BASE=/path/to/epics-base
 
 # Set RULES here if you want to take build rules from somewhere
 # other than EPICS_BASE:
 #RULES=/path/to/epics/support/module/rules/x-y
+
+# The definitions shown below can also be placed in an untracked RELEASE.local
+-include $(TOP)/../RELEASE.local
+-include $(TOP)/configure/RELEASE.local

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+recsync (1.3.5) unstable; urgency=medium
+
+  * Fix bug with client that caused RIDs to be reused when more than 65536 records
+
+ -- Dylan Maxwell <maxwelld@frib.msu.edu>  Thu, 27 Feb 2019 17:25:14 -0400
+
 recsync (1.3.4) unstable; urgency=low
 
   * Record Alias in CF

--- a/debian/rules
+++ b/debian/rules
@@ -31,6 +31,7 @@ override_dh_auto_install:
 	cp server/demo.conf debian/recceiver/etc/recceiver.conf
 
 override_dh_install:
+	rm -f debian/tmp/usr/lib/epics/configure/RELEASE.local
 	dh_install --fail-missing
 
 override_dh_installinit:

--- a/debian/rules
+++ b/debian/rules
@@ -10,10 +10,13 @@ export SHRLIB_VERSION=1
 	dh $@ --with epics --with python2 --parallel
 
 override_dh_auto_clean:
+	echo "EPICS_BASE=/usr/lib/epics" > client/configure/RELEASE.local
 	dh_auto_clean -Sepicsmake -Dclient
 	dh_auto_clean -Spybuild -Dserver
+	rm -f client/configure/RELEASE.local
 
 override_dh_auto_configure:
+	echo "EPICS_BASE=/usr/lib/epics" > client/configure/RELEASE.local
 	dh_auto_configure -Sepicsmake -Dclient
 	dh_auto_configure -Spybuild -Dserver
 


### PR DESCRIPTION
The use of `htons` caused the RID to increment is steps of 65536 and as a resulted limited the number of unique RIDs to 65536.  The problem can be masked if the server create small Transaction objects that contain less than 65536 records.

This should explain at least some of the salability (#27) problems we have been seeing.

@mdavidsaver I tried to find all places where rid is assigned, but I would appreciate your review.