### PR TITLE
Allow selection of server ports

### DIFF
--- a/server/cf.conf
+++ b/server/cf.conf
@@ -9,6 +9,11 @@
 # for local testing w/ firewall
 #addrlist = 127.255.255.255:5049
 
+# Listen for TCP connections on this interface and port.
+# Port also used as source for UDP broadcasts.
+# Default uses wildcard address and a random port.
+#bind = 0.0.0.0:0
+
 # Processing chain
 procs = cf
 

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -12,6 +12,11 @@
 # for local testing w/ firewall
 #addrlist = 127.255.255.255:5049
 
+# Listen for TCP connections on this interface and port.
+# Port also used as source for UDP broadcasts
+# Default uses wildcard address and a random port.
+#bind = 0.0.0.0:0
+
 # Processing chain
 # sequence of plugin names seperated by ','
 #


### PR DESCRIPTION
Addresses #40.

The only complication is what appears to be inconsistent behavior wrt.calling  `Port.startListening()`.  I recall that this was required when I first started using Twisted, however with Twisted 16.6.0 it is an error.  I'm not planning to investigate the history of this.