### PR TITLE
Update configuration files to match latest epics modules environment

### DIFF
--- a/client/configure/CONFIG_SITE
+++ b/client/configure/CONFIG_SITE
@@ -19,7 +19,7 @@ CHECK_RELEASE = YES
 # Set this when you only want to compile this application
 #   for a subset of the cross-compiled target architectures
 #   that Base is built for.
-CROSS_COMPILER_TARGET_ARCHS = $(EPICS_HOST_ARCH)-debug
+#CROSS_COMPILER_TARGET_ARCHS = $(EPICS_HOST_ARCH)-debug
 #CROSS_COMPILER_TARGET_ARCHS += win32-x86-mingw
 
 # To install files into a location other than $(TOP) define
@@ -32,3 +32,14 @@ CROSS_COMPILER_TARGET_ARCHS = $(EPICS_HOST_ARCH)-debug
 # You must rebuild in the iocBoot directory for this to
 #   take effect.
 #IOCS_APPL_TOP = </IOC/path/to/application/top>
+
+USR_CXXFLAGS += -DUSE_TYPED_RSET
+
+# These allow developers to override the CONFIG_SITE variable
+# settings without having to modify the configure/CONFIG_SITE
+# file itself.
+# To keep the same depth of other EPICS modules, we have to add
+# the additional `/../`, because of `client` directory.
+-include $(TOP)/../../CONFIG_SITE.local
+-include $(TOP)/../../configure/CONFIG_SITE.local
+-include $(TOP)/configure/CONFIG_SITE.local

--- a/client/configure/RELEASE
+++ b/client/configure/RELEASE
@@ -28,6 +28,10 @@
 # other than EPICS_BASE:
 #RULES=/path/to/epics/support/module/rules/x-y
 
-# The definitions shown below can also be placed in an untracked RELEASE.local
--include $(TOP)/../RELEASE.local
+# These allow developers to override the RELEASE variable settings
+# without having to modify the configure/RELEASE file itself.
+# To keep the same depth of other EPICS modules, we have to add
+# the additional `/../`, because of `client` directory.
+-include $(TOP)/../../RELEASE.local
+-include $(TOP)/../../configure/RELEASE.local
 -include $(TOP)/configure/RELEASE.local


### PR DESCRIPTION
Hi @shroffk and @mdavidsaver 

   In order to use the recsync client epics module in the same way that other EPICS modules use, I changed two configuration files.  For example, `RELEASE` and `CONFIG_SITE` in `client/configure` path have the following lines at the end of it.

```bash
-include $(TOP)/../../CONFIG_SITE.local
-include $(TOP)/../../configure/CONFIG_SITE.local
-include $(TOP)/configure/CONFIG_SITE.local

-include $(TOP)/../../RELEASE.local
-include $(TOP)/../../configure/RELEASE.local
-include $(TOP)/configure/RELEASE.local
```

In addition, add the ` -DUSE_TYPED_RSET` for the compiler flag, and comment out the debug target also, which was mentioned in https://github.com/ChannelFinder/recsync/pull/45


Please look at them, and let me know. 

