### PR TITLE
[WIP] Resolves #52

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,8 +216,10 @@ The header will have the form
   <td>ATYPE</td>
   <td>RTLEN</td>
   <td colspan="2">RNLEN</td>
+  <td>RDLEN</td>
   <td>RTYPE</td>
   <td>RNAME</td>
+  <td>RDESC</td>
  </tr>
  <tr>
   <td>0x0004</td>
@@ -251,11 +253,11 @@ The header will have the form
 * `SERV KEY` must be the number the client received in the announcement from which it found this server.
 * `RECID` is an identifier choosen by the client to identify a single record instance.  Except in Add Info, must be >0.
 * `ATYPE` is 0 to add a record entry or 1 to add a record alias.  When adding an alias the record type is omitted (`RTLEN`==0) and the `RECID` must have been added in a previous message with `ATYPE`==0.
-* `RTLEN`, `RNLEN`, `KEYLEN`, and `VALEN` are lengths in bytes.
-* `RTLEN` and `VALEN` are allowed to be zero.
+* `RTLEN`, `RNLEN`, `RDLEN`, `KEYLEN`, and `VALEN` are lengths in bytes.
+* `RTLEN`, `RDLEN` and `VALEN` are allowed to be zero.
 * `RNLEN` and `KEYLEN` must be greater than zero.
-* `RTYPE`, `RNAME`, `KEY`, and `VALUE` are variable length fields whos length is given by the corresponding `*LEN` field.
-* `RTYPE`, `RNAME`, `KEY`, and `VALUE` should not include a 0 (ascii null) byte.
+* `RTYPE`, `RNAME`, `RDLEN`, `KEY`, and `VALUE` are variable length fields whos length is given by the corresponding `*LEN` field.
+* `RTYPE`, `RNAME`, `RDLEN`, `KEY`, and `VALUE` should not include a 0 (ascii null) byte.
 * The `RECID` field of the Add Info may be zero.  When zero the key/value pair is considered to be associated with the client as a whole, and not any individual record.
 
 When a TCP connection is established the client must send the Client Greeting message

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -213,7 +213,7 @@ ssize_t casterSendRecord(caster_t* self, const char* rtype, const char* rname, c
 
     rid = self->nextRecID++;
 
-    if(casterSendRA(self, 0, rid, rtype, rname))
+    if(casterSendRA(self, 0, rid, rtype, rname, rdesc))
         return -1;
     return rid;
 }

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -173,18 +173,19 @@ void casterMsg(caster_t *self, const char* msg, ...)
 }
 
 static
-ssize_t casterSendRA(caster_t* self, epicsUInt8 type, size_t rid, const char* rtype, const char* rname)
+ssize_t casterSendRA(caster_t* self, epicsUInt8 type, size_t rid, const char* rtype, const char* rname, const char* rdesc)
 {
     union casterTCPBody buf;
     epicsUInt32 blen = sizeof(buf.c_add);
-    size_t lt=rtype ? strlen(rtype) : 0, ln=strlen(rname);
+    size_t lt=rtype ? strlen(rtype) : 0, ln=strlen(rname), ld=rdesc ? strlen(rdesc) : 0;
 
     buf.c_add.rid = htonl(rid);
     buf.c_add.rtype = type;
     buf.c_add.rtlen = lt;
     buf.c_add.rnlen = htons(ln);
+    buf.c_add.rdlen = ld;
 
-    blen += lt + ln;
+    blen += lt + ln + ld;
 
     if(casterSendPHead(self->csock, 0x0003, blen)!=1)
         return -1;
@@ -197,11 +198,13 @@ ssize_t casterSendRA(caster_t* self, epicsUInt8 type, size_t rid, const char* rt
 
     if(shSendAll(self->csock, rname, ln, 0)!=1)
         return -1;
+    
+    if(shSendAll(self->csock, rdesc, ld, 0)!=1)
 
     return 0;
 }
 
-ssize_t casterSendRecord(caster_t* self, const char* rtype, const char* rname)
+ssize_t casterSendRecord(caster_t* self, const char* rtype, const char* rname, const char* rdesc)
 {
     size_t rid;
 
@@ -215,9 +218,9 @@ ssize_t casterSendRecord(caster_t* self, const char* rtype, const char* rname)
     return rid;
 }
 
-ssize_t casterSendAlias(caster_t* self, size_t rid, const char* rname)
+ssize_t casterSendAlias(caster_t* self, size_t rid, const char* rname, const char* rdesc)
 {
-    return casterSendRA(self, 1, rid, NULL, rname);
+    return casterSendRA(self, 1, rid, NULL, rname, rdesc);
 }
 
 int casterSendInfo(caster_t *self, ssize_t rid, const char* name, const char* val)

--- a/client/castApp/src/caster.h
+++ b/client/castApp/src/caster.h
@@ -76,9 +76,9 @@ epicsShareFunc
 int casterStart(caster_t *self);
 
 epicsShareFunc
-ssize_t casterSendRecord(caster_t* c, const char* rtype, const char* rname);
+ssize_t casterSendRecord(caster_t* c, const char* rtype, const char* rname, const char* rdesc);
 epicsShareFunc
-ssize_t casterSendAlias(caster_t* c, size_t rid, const char* rname);
+ssize_t casterSendAlias(caster_t* c, size_t rid, const char* rname, const char* rdesc);
 epicsShareFunc
 int casterSendInfo(caster_t *c, ssize_t rid, const char* name, const char* val);
 

--- a/client/castApp/src/caster.h
+++ b/client/castApp/src/caster.h
@@ -182,6 +182,7 @@ typedef struct {
     epicsUInt8 rtype; /* 0 - IOC Rec, 1 - IOC Alias */
     epicsUInt8 rtlen; /* # of bytes in record type name (0 for aliases) */
     epicsUInt16 rnlen; /* # of bytes in record instance name */
+    epicsUInt32 rdlen; /* # of bytes in record desc */
     /* record type and instance names follow */
 } casterClientAddRec; /* 0x0003 */
 

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -94,7 +94,7 @@ static int pushRecord(caster_t *caster, DBENTRY *pent)
             if(dbIsAlias(&subent) &&
                subent.precnode->precord == prec)
             {
-                ret = casterSendAlias(caster, rid, subent.precnode->recordname, subent.precnode->precord->desc);
+                ret = casterSendAlias(caster, rid, subent.precnode->recordname, prec->desc);
             }
         }
 

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -94,7 +94,7 @@ static int pushRecord(caster_t *caster, DBENTRY *pent)
             if(dbIsAlias(&subent) &&
                subent.precnode->precord == prec)
             {
-                ret = casterSendAlias(caster, rid, subent.precnode->recordname, subent.precnode->precord.desc);
+                ret = casterSendAlias(caster, rid, subent.precnode->recordname, subent.precnode->precord->desc);
             }
         }
 

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -79,7 +79,7 @@ static int pushRecord(caster_t *caster, DBENTRY *pent)
     if(dbIsAlias(pent))
         return 0;
 
-    rid = casterSendRecord(caster, prec->rdes->name, prec->name);
+    rid = casterSendRecord(caster, prec->rdes->name, prec->name, prec->desc);
     if(rid<=0)
         return rid;
 
@@ -94,7 +94,7 @@ static int pushRecord(caster_t *caster, DBENTRY *pent)
             if(dbIsAlias(&subent) &&
                subent.precnode->precord == prec)
             {
-                ret = casterSendAlias(caster, rid, subent.precnode->recordname);
+                ret = casterSendAlias(caster, rid, subent.precnode->recordname, subent.precnode->precord.desc);
             }
         }
 

--- a/client/castApp/src/testtcp.c
+++ b/client/castApp/src/testtcp.c
@@ -211,7 +211,7 @@ static void testCB(void)
     sock[0].sd = sd[0];
     sock[1].sd = sd[1];
 
-    testOk1(casterSendRecord(&caster, "hello", "world")==42);
+    testOk1(casterSendRecord(&caster, "hello", "world", "desc")==42);
 
     testOk1(caster.nextRecID==43);
 

--- a/server/cf.conf
+++ b/server/cf.conf
@@ -40,3 +40,4 @@ procs = cf
 # Turn on optional alias and recordType properties
 #alias = on
 #recordType = on
+#recordDesc = on

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -70,6 +70,10 @@ idkey = 42
 # cf-store application
 # Uncomment line below to turn on the feature to add alias records to channelfinder
 # alias = on
+# Uncomment line below to turn on the feature to add EPICS record type to channelfinder
+# recordType = on
+# Uncomment line below to turn on the feature to add description field to channelfinder
+# recordDesc = on
 # The size limit for finding channels (ie the value of the '~size' query parameter)
 # If not specified then the fallback is the server default
 # findSizeLimit = 10000

--- a/server/recceiver.sqlite3
+++ b/server/recceiver.sqlite3
@@ -22,6 +22,7 @@ CREATE TABLE record (
   pkey INTEGER PRIMARY KEY,
   id INTEGER NOT NULL,
   rtype STRING,
+  rdesc STRING,
   host INTEGER NOT NULL REFERENCES server(id) ON DELETE CASCADE,
   UNIQUE(id, host)
 );

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -77,6 +77,8 @@ class CFProcessor(service.Service):
                     reqd_props.add('alias')
                 if (self.conf.get('recordType', 'default') == 'on'):
                     reqd_props.add('recordType')
+                if (self.conf.get('recordDesc', 'default') == 'on'):
+                    reqd_props.add('recordDesc')
                 wl = self.conf.get('infotags', list())
                 whitelist = [s.strip(', ') for s in wl.split()] \
                     if wl else wl
@@ -172,10 +174,12 @@ class CFProcessor(service.Service):
         iocid = host + ":" + str(port)
 
         pvInfo = {}
-        for rid, (rname, rtype) in TR.addrec.items():
+        for rid, (rname, rtype, rdesc) in TR.addrec.items():
             pvInfo[rid] = {"pvName": rname}
             if (self.conf.get('recordType', 'default' == 'on')):
                 pvInfo[rid]['recordType'] = rtype
+            if (self.conf.get('recordDesc', 'default') == 'on'):
+                pvInfo[rid]['recordDesc'] = rdesc
         for rid, (recinfos) in TR.recinfos.items():
             # find intersection of these sets
             if rid not in pvInfo:
@@ -188,11 +192,13 @@ class CFProcessor(service.Service):
                     property = {u'name': infotag, u'owner': owner,
                                 u'value': recinfos[infotag]}
                     pvInfo[rid]['infoProperties'].append(property)
-        for rid, alias in TR.aliases.items():
+        for rid, (alias, aliasDesc) in TR.aliases.items():
             if rid not in pvInfo:
                 _log.warn('IOC: %s: PV not found for alias with RID: %s', iocid, rid)
                 continue
             pvInfo[rid]['aliases'] = alias
+            if (self.conf.get('recordDesc', 'default') == 'on'):
+                pvInfo[rid]['aliasDesc'] = aliasDesc
 
         delrec = list(TR.delrec)
         _log.debug("Delete records: %s", delrec)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -351,7 +351,7 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                         if iocs[channels_dict[ch[u'name']][-1]]["recordDesc"] != "":
                             ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordDesc', u'owner': owner, u'value': iocs[channels_dict[ch[u'name']][-1]]["recordDesc"]}), ch[u'properties'])
                         else: # recordDesc == ""
-                            ch[u'properties'] = [prop for prop in ch[u'propery'] if prop[u'name'] != 'recordDesc']
+                            ch[u'properties'] = [prop for prop in ch[u'properties'] if prop[u'name'] != 'recordDesc']
                     channels.append(ch)
                     _log.debug("Add existing channel to previous IOC: %s", channels[-1])
                     """In case alias exist, also delete them"""
@@ -374,7 +374,7 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                                         if iocs[channels_dict[a[u'name']][-1]]["recordDesc"] != "":
                                             ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordDesc', u'owner': owner, u'value': iocs[channels_dict[a[u'name']][-1]]["recordDesc"]}), ch[u'properties'])
                                         else: # recordDesc == ""
-                                            ch[u'properties'] = [prop for prop in ch[u'propery'] if prop[u'name'] != 'recordDesc']
+                                            ch[u'properties'] = [prop for prop in ch[u'properties'] if prop[u'name'] != 'recordDesc']
                                     channels.append(a)
                                     _log.debug("Add existing alias to previous IOC: %s", channels[-1])
 
@@ -469,6 +469,9 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
             # CF doesn't like empty or null properties
             if pvInfoByName[pv]['recordDesc'] != "":
                 newProps.append({u'name': 'recordDesc', u'owner': owner, u'value': pvInfoByName[pv]['recordDesc']})
+            else: # recordDesc == ""
+                if pv in existingChannels:
+                    existingChannels[pv]["properties"] = [prop for prop in existingChannels[pv]["properties"] if prop[u'name'] != 'recordDesc']
         if pv in pvInfoByName and "infoProperties" in pvInfoByName[pv]:
             newProps = newProps + pvInfoByName[pv]["infoProperties"]
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -350,6 +350,8 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                         # CF doesn't like empty or null properties
                         if iocs[channels_dict[ch[u'name']][-1]]["recordDesc"] != "":
                             ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordDesc', u'owner': owner, u'value': iocs[channels_dict[ch[u'name']][-1]]["recordDesc"]}), ch[u'properties'])
+                        else: # recordDesc == ""
+                            ch[u'properties'] = [prop for prop in ch[u'propery'] if prop[u'name'] != 'recordDesc']
                     channels.append(ch)
                     _log.debug("Add existing channel to previous IOC: %s", channels[-1])
                     """In case alias exist, also delete them"""
@@ -371,6 +373,8 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                                         # CF doesn't like empty or null properties
                                         if iocs[channels_dict[a[u'name']][-1]]["recordDesc"] != "":
                                             ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordDesc', u'owner': owner, u'value': iocs[channels_dict[a[u'name']][-1]]["recordDesc"]}), ch[u'properties'])
+                                        else: # recordDesc == ""
+                                            ch[u'properties'] = [prop for prop in ch[u'propery'] if prop[u'name'] != 'recordDesc']
                                     channels.append(a)
                                     _log.debug("Add existing alias to previous IOC: %s", channels[-1])
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -346,6 +346,10 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                                                                ch[u'properties'])
                     if (conf.get('recordType', 'default') == 'on'):
                         ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordType', u'owner': owner, u'value': iocs[channels_dict[ch[u'name']][-1]]["recordType"]}), ch[u'properties'])
+                    if (conf.get('recordDesc', 'default') == 'on'):
+                        # CF doesn't like empty or null properties
+                        if iocs[channels_dict[ch[u'name']][-1]]["recordDesc"] != "":
+                            ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordDesc', u'owner': owner, u'value': iocs[channels_dict[ch[u'name']][-1]]["recordDesc"]}), ch[u'properties'])
                     channels.append(ch)
                     _log.debug("Add existing channel to previous IOC: %s", channels[-1])
                     """In case alias exist, also delete them"""
@@ -363,6 +367,10 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                                                                             a[u'properties'])
                                     if (conf.get('recordType', 'default') == 'on'):
                                         ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordType', u'owner': owner, u'value': iocs[channels_dict[a[u'name']][-1]]["recordType"]}), ch[u'properties'])
+                                    if (conf.get('recordDesc', 'default') == 'on'):
+                                        # CF doesn't like empty or null properties
+                                        if iocs[channels_dict[a[u'name']][-1]]["recordDesc"] != "":
+                                            ch[u'properties'] = __merge_property_lists(ch[u'properties'].append({u'name': 'recordDesc', u'owner': owner, u'value': iocs[channels_dict[a[u'name']][-1]]["recordDesc"]}), ch[u'properties'])
                                     channels.append(a)
                                     _log.debug("Add existing alias to previous IOC: %s", channels[-1])
 
@@ -453,6 +461,10 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
                      {u'name': 'time', u'owner': owner, u'value': iocTime}]
         if (conf.get('recordType', 'default') == 'on'):
             newProps.append({u'name': 'recordType', u'owner': owner, u'value': pvInfoByName[pv]['recordType']})
+        if (conf.get('recordDesc', 'default') == 'on'):
+            # CF doesn't like empty or null properties
+            if pvInfoByName[pv]['recordDesc'] != "":
+                newProps.append({u'name': 'recordDesc', u'owner': owner, u'value': pvInfoByName[pv]['recordDesc']})
         if pv in pvInfoByName and "infoProperties" in pvInfoByName[pv]:
             newProps = newProps + pvInfoByName[pv]["infoProperties"]
 

--- a/server/recceiver/dbstore.py
+++ b/server/recceiver/dbstore.py
@@ -113,14 +113,14 @@ class DBProcessor(service.Service):
                         ))
 
         # Start new records
-        cur.executemany('INSERT INTO %s (host, id, rtype) VALUES (?,?,?)' % self.trecord,
-                        [(srvid, recid, rtype) for recid, (rname, rtype) in TR.addrec.items()])
+        cur.executemany('INSERT INTO %s (host, id, rtype, rdesc) VALUES (?,?,?,?)' % self.trecord,
+                        [(srvid, recid, rtype, rdesc) for recid, (rname, rtype, rdesc) in TR.addrec.items()])
 
         # Add primary record names
         cur.executemany("""INSERT INTO %s (rec, rname, prim) VALUES (
                          (SELECT pkey FROM %s WHERE id=? AND host=?)
                          ,?,1)""" % (self.tname, self.trecord),
-                        [(recid, srvid, rname) for recid, (rname, rtype) in TR.addrec.items()])
+                        [(recid, srvid, rname) for recid, (rname, rtype, rdesc) in TR.addrec.items()])
 
         # Add new record aliases
         cur.executemany("""INSERT INTO %(name)s (rec, rname, prim) VALUES (
@@ -128,7 +128,7 @@ class DBProcessor(service.Service):
                          ,?,0)""" % {'name': self.tname, 'rec': self.trecord},
                         [(recid, srvid, rname)
                          for recid, names in TR.aliases.items()
-                         for rname in names
+                         for rname, rdesc in names
                          ])
 
         # add record infos

--- a/server/recceiver/interfaces.py
+++ b/server/recceiver/interfaces.py
@@ -9,7 +9,7 @@ class ITransaction(Interface):
     src = Attribute('Source Address.')
     
     addrec = Attribute("""Records being added
-    {recid: ('recname', 'rectype', {'key':'val'})}
+    {recid: ('recname', 'rectype', 'recdesc', {'key':'val'})}
     """)
     
     delrec = Attribute('A set() of recids which are being removed')

--- a/server/recceiver/recast.py
+++ b/server/recceiver/recast.py
@@ -37,8 +37,8 @@ assert _c_greet.size==8
 _c_info = struct.Struct('>IBxH')
 assert _c_info.size==8
 
-_c_rec = struct.Struct('>IBBH')
-assert _c_rec.size==8
+_c_rec = struct.Struct('>IBBHI')
+assert _c_rec.size==12
 
 class CastReceiver(stateful.StatefulProtocol):
 
@@ -163,21 +163,23 @@ class CastReceiver(stateful.StatefulProtocol):
 
     # 0x0003
     def recvAddRec(self, body):
-        rid, rtype, rtlen, rnlen = _c_rec.unpack(body[:_c_rec.size])
+        rid, rtype, rtlen, rnlen, rdlen = _c_rec.unpack(body[:_c_rec.size])
         text = body[_c_rec.size:]
         if PYTHON3:
             text = text.decode()
-        if rnlen==0 or rtlen+rnlen<len(text):
+        if rnlen==0 or rtlen+rnlen+rdlen<len(text):
             _log.error('Ignoring record update')
 
         elif rtlen>0 and rtype==0:# new record
             rectype = text[:rtlen]
             recname = text[rtlen:rtlen+rnlen]
-            self.sess.addRecord(rid, rectype, recname)
+            recdesc = text[rtlen+rnlen:rtlen+rnlen+rdlen]
+            self.sess.addRecord(rid, rectype, recname, recdesc)
 
         elif rtype==1: # record alias
             recname = text[rtlen:rtlen+rnlen]
-            self.sess.addAlias(rid, recname)
+            recdesc = text[rtlen+rnlen:rtlen+rnlen+rdlen]
+            self.sess.addAlias(rid, recname, recdesc)
 
         return self.getInitialState()
 
@@ -311,13 +313,13 @@ class CollectionSession(object):
         self.TR.infos[key] = val
         self.markDirty()
 
-    def addRecord(self, rid, rtype, rname):
+    def addRecord(self, rid, rtype, rname, rdesc):
         self.flushSafely()
-        self.TR.addrec[rid] = (rname, rtype)
+        self.TR.addrec[rid] = (rname, rtype, rdesc)
         self.markDirty()
 
-    def addAlias(self, rid, rname):
-        self.TR.aliases[rid].append(rname)
+    def addAlias(self, rid, rname, rdesc):
+        self.TR.aliases[rid].append((rname, rdesc))
         self.markDirty()
 
     def delRecord(self, rid):


### PR DESCRIPTION
This PR targets adding the DESC field of PV's on the CF and in the storage DB.

As discussed in #52 adding the DESC field can be very useful for a lot of scenarios.
There is already an implementation on https://github.com/lnls-sol/recsync/pull/1 , however there are some concerns over that implementation that we need to fix/discuss:
- Should we always send the DESC field information? Descriptions can be big, and thus we should think if this can create a network traffic problem.
- We should add in the server side a flag as default to off for capturing the DESC, so we don't break any running system.