### PR TITLE
Second PR to address #52 (recordDesc as INFO tag)

### DIFF
--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -111,6 +111,12 @@ static int pushRecord(caster_t *caster, DBENTRY *pent)
             ret = casterSendInfo(caster, rid, name, val);
     }
 
+    /* send desc as INFO tag */
+    const char *name = "recordDesc";
+    const char *val= prec->desc;
+    if(val && val[0]!='\0')
+        ret = casterSendInfo(caster, rid, name, val);
+
     return ret;
 }
 

--- a/server/cf.conf
+++ b/server/cf.conf
@@ -40,3 +40,4 @@ procs = cf
 # Turn on optional alias and recordType properties
 #alias = on
 #recordType = on
+#recordDesc = on

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -70,6 +70,10 @@ idkey = 42
 # cf-store application
 # Uncomment line below to turn on the feature to add alias records to channelfinder
 # alias = on
+# Uncomment line below to turn on the feature to add EPICS record type to channelfinder
+# recordType = on
+# Uncomment line below to turn on the feature to add description field to channelfinder
+# recordDesc = on
 # The size limit for finding channels (ie the value of the '~size' query parameter)
 # If not specified then the fallback is the server default
 # findSizeLimit = 10000

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -80,6 +80,8 @@ class CFProcessor(service.Service):
                 wl = self.conf.get('infotags', list())
                 whitelist = [s.strip(', ') for s in wl.split()] \
                     if wl else wl
+                if (self.conf.get('recordDesc', 'default') == 'on'):
+                    whitelist.append('recordDesc')
                 # Are any required properties not already present on CF?
                 properties = reqd_props - set(cf_props)
                 # Are any whitelisted properties not already present on CF?


### PR DESCRIPTION
https://github.com/ChannelFinder/recsync/issues/52

This would be an alternative to the original pull request: https://github.com/ChannelFinder/recsync/pull/53

Pretends recordDesc is an INFO tag.
