### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -57,7 +57,7 @@ jobs:
             base: "7.0"
             extra: "CMD_CXXFLAGS=-std=c++11"
 
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             cmp: clang
             configuration: default
             base: "7.0"
@@ -80,20 +80,20 @@ jobs:
             base: "7.0"
             rtems: "4.9"
 
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             cmp: gcc-4.8
             utoolchain: true
             configuration: default
             base: "7.0"
 
-          - os: ubuntu-16.04
+          - os: ubuntu-18.04
             cmp: gcc-4.9
             utoolchain: true
             configuration: default
             base: "7.0"
 
           - os: ubuntu-20.04
-            cmp: gcc-8
+            cmp: g++-8
             utoolchain: true
             configuration: default
             base: "7.0"


### PR DESCRIPTION
Updated ubuntu 16.04 to 18.04 per this: https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/

This fixes 3/4 failed runs. The last one is Ubuntu 18.04 with gcc 4.9. Looks like that gcc version isn't available via the ppa. Remove the test? Or add some lines here to get gcc 4.9 working https://github.com/ChannelFinder/recsync/blob/master/.github/workflows/ci-scripts-build.yml#L123