### PR TITLE
Extend portability

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -16,96 +16,113 @@ env:
 
 jobs:
   build-client:
-    name: ${{ matrix.base }}/${{ matrix.os }}/${{ matrix.cmp }}/${{ matrix.configuration }}${{ matrix.rtems }}/${{ matrix.extra }}
+    name: ${{ matrix.name }}
     runs-on: ${{ matrix.os }}
     # Set environment variables from matrix parameters
     env:
       BASE: ${{ matrix.base }}
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
-      RTEMS: ${{ matrix.rtems }}
+      CI_CROSS_TARGETS: ${{ matrix.cross }}
       EXTRA: ${{ matrix.extra }}
       TEST: ${{ matrix.test }}
     strategy:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
+          - name: Linux-Mingw-7.0
+            os: ubuntu-latest
             cmp: gcc
             configuration: default
             base: "7.0"
-            wine: "64"
+            cross: "windows-x64-mingw"
 
-          - os: ubuntu-latest
+          - name: Linux-static-7.0
+            os: ubuntu-latest
             cmp: gcc
             configuration: static
             base: "7.0"
 
-          - os: ubuntu-latest
+          - name: Linux-3.15
+            os: ubuntu-latest
             cmp: gcc
             configuration: default
             base: "3.15"
 
-          - os: ubuntu-latest
+          - name: Linux-3.14
+            os: ubuntu-latest
             cmp: gcc
             configuration: default
             base: "3.14"
 
-          - os: ubuntu-latest
+          - name: Linux-c++11-7.0
+            os: ubuntu-latest
             cmp: gcc
             configuration: static
             base: "7.0"
             extra: "CMD_CXXFLAGS=-std=c++11"
 
-          - os: ubuntu-latest
-            cmp: gcc
+          - name: Linux-clang-7.0
+            os: ubuntu-latest
+            cmp: clang
             configuration: default
             base: "7.0"
 
-          - os: ubuntu-latest
+          - name: Linux-clang-c++11-7.0
+            os: ubuntu-latest
             cmp: clang
             configuration: default
             base: "7.0"
             extra: "CMD_CXXFLAGS=-std=c++11"
 
-          - os: ubuntu-latest
+          - name: Linux-rtems5-7.0
+            os: ubuntu-20.04
             cmp: gcc
             configuration: default
             base: "7.0"
-            rtems: "4.10"
+            cross: "RTEMS-pc686-qemu@5"
 
-          - os: ubuntu-latest
+          - name: Linux-rtems4.10-7.0
+            os: ubuntu-20.04
             cmp: gcc
             configuration: default
             base: "7.0"
-            rtems: "4.9"
+            cross: "RTEMS-pc386-qemu@4.10"
+            test: NO
 
-          - os: ubuntu-latest
+          - name: Linux-rtems4.9-7.0
+            os: ubuntu-20.04
+            cmp: gcc
+            configuration: default
+            base: "7.0"
+            cross: "RTEMS-pc386-qemu@4.9"
+
+          - name: OSX-7.0
+            os: macos-latest
             cmp: clang
             configuration: default
             base: "7.0"
 
-          - os: macos-latest
-            cmp: clang
+          - name: msvc-7.0
+            os: windows-latest
+            cmp: vs2022
             configuration: default
             base: "7.0"
 
-          - os: windows-2019
-            cmp: vs2019
-            configuration: default
-            base: "7.0"
-
-          - os: windows-2019
-            cmp: vs2019
+          - name: msvc-static-7.0
+            os: windows-latest
+            cmp: vs2022
             configuration: static
             base: "7.0"
 
-          - os: windows-2019
-            cmp: vs2019
+          - name: msvc-debug-7.0
+            os: windows-latest
+            cmp: vs2022
             configuration: debug
             base: "7.0"
 
-          - os: windows-2019
+          - name: mingw-7.0
+            os: windows-latest
             cmp: gcc
             configuration: default
             base: "7.0"
@@ -114,7 +131,7 @@ jobs:
       run:
         working-directory: client
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Automatic core dump analysis
@@ -130,14 +147,15 @@ jobs:
       run: python .ci/cue.py build
     - name: Run main module tests
       run: python .ci/cue.py test
-    - name: Collect and show test results
-      run: python .ci/cue.py test-results
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'
+    - name: Collect and show test results
+      if: ${{ always() }}
+      run: python .ci/cue.py test-results
 
   docker:
     name: ${{ matrix.name }}
@@ -148,7 +166,6 @@ jobs:
       CMP: ${{ matrix.cmp }}
       BCFG: ${{ matrix.configuration }}
       BASE: ${{ matrix.base }}
-      WINE: ${{ matrix.wine }}
       LIBEVENT_TAG: ${{ matrix.libevent }}
       EXTRA: ${{ matrix.extra }}
       VV: "1"
@@ -194,7 +211,7 @@ jobs:
         # people would rather just break all existing scripts...
         [ -e /usr/bin/python ] || ln -sf /usr/bin/python3 /usr/bin/python
         python --version
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
       with:
         submodules: true
     - name: Automatic core dumper analysis
@@ -208,12 +225,13 @@ jobs:
     - name: Run main module tests
       working-directory: ./client
       run: python .ci/cue.py test
-    - name: Collect and show test results
-      working-directory: ./client
-      run: python .ci/cue.py test-results
     - name: Upload tapfiles Artifact
       if: ${{ always() }}
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: tapfiles ${{ matrix.name }}
         path: '**/O.*/*.tap'
+    - name: Collect and show test results
+      if: ${{ always() }}
+      working-directory: ./client
+      run: python .ci/cue.py test-results

--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -85,6 +85,31 @@ jobs:
             configuration: default
             base: "7.0"
 
+          - os: macos-latest
+            cmp: clang
+            configuration: default
+            base: "7.0"
+
+          - os: windows-2019
+            cmp: vs2019
+            configuration: default
+            base: "7.0"
+
+          - os: windows-2019
+            cmp: vs2019
+            configuration: static
+            base: "7.0"
+
+          - os: windows-2019
+            cmp: vs2019
+            configuration: debug
+            base: "7.0"
+
+          - os: windows-2019
+            cmp: gcc
+            configuration: default
+            base: "7.0"
+
     defaults:
       run:
         working-directory: client

--- a/client/castApp/src/Makefile
+++ b/client/castApp/src/Makefile
@@ -10,6 +10,9 @@ LIBRARY_IOC = reccaster
 # Will increment with ABI changes
 SHRLIB_VERSION = 0
 
+PROD_SYS_LIBS_WIN32 = iphlpapi netapi32 ws2_32
+LIB_SYS_LIBS_WIN32 = iphlpapi netapi32 ws2_32
+
 reccaster_SRCS += sockhelpers.c
 reccaster_SRCS += caster.c
 reccaster_SRCS += castudp.c

--- a/client/castApp/src/Makefile
+++ b/client/castApp/src/Makefile
@@ -46,6 +46,10 @@ testAddEnvVars_SYS_LIBS_WIN32 = ws2_32
 TESTS += testAddEnvVars
 
 TESTSCRIPTS_HOST += $(TESTS:%=%.t)
+ifneq ($(filter $(T_A),$(CROSS_COMPILER_RUNTEST_ARCHS)),)
+TESTPROD = $(TESTPROD_HOST)
+TESTSCRIPTS += $(TESTSCRIPTS_HOST)
+endif
 
 #===========================
 

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -101,8 +101,7 @@ static void casterThread(void* junk)
 static
 void casterShowMsgDefault(void* arg, struct _caster_t* self)
 {
-    errlogMessage(self->lastmsg);
-    errlogMessage("\n");
+    errlogPrintf("%s\n", self->lastmsg);
 }
 
 void casterInit(caster_t *self)

--- a/client/castApp/src/castinit.c
+++ b/client/castApp/src/castinit.c
@@ -202,6 +202,7 @@ static void addReccasterEnvVarsCallFunc(const iocshArgBuf *args)
 
 static void reccasterRegistrar(void)
 {
+    osiSockAttach();
     initHookRegister(&casthook);
     casterInit(&thecaster);
     thepriv.lock = epicsMutexMustCreate();

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -174,8 +174,8 @@ int socketpair_compat(int af, int st, int p, SOCKET sd[2])
     return 0;
 fail:
     if(listener!=INVALID_SOCKET)
-        epicsSocketDestroy(sd[0]);
-    if(listener!=INVALID_SOCKET)
+        epicsSocketDestroy(listener);
+    if(sd[0]!=INVALID_SOCKET)
         epicsSocketDestroy(sd[0]);
     if(sd[1]!=INVALID_SOCKET)
         epicsSocketDestroy(sd[1]);

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -83,10 +83,15 @@ int socketpair_compat(int af, int st, int p, SOCKET sd[2])
     if(listen(listener, 2))
         goto fail;
 
-    /* we can't possibly succeed immediately */
+    /* begin async connect(), which can't possibly succeed before accept() */
     if(connect(sd[1], &ep[0].sa, sizeof(ep[0]))==0) {
+#ifdef __rtems__
+        /* except for RTEMS, which is special... */
+        errno = SOCK_EWOULDBLOCK;
+#else
         ret = -2;
         goto fail;
+#endif
     }
 
     if(SOCKERRNO!=SOCK_EINPROGRESS && SOCKERRNO!=SOCK_EWOULDBLOCK) {

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -152,10 +152,14 @@ int shSocketPair(SOCKET sd[2])
      * RTEMS 4 (classic stack) provides a no-op stub
      */
 #if defined(_WIN32) || defined(__rtems__)
-    return socketpair_compat(AF_INET, SOCK_STREAM, 0, sd);
+    int ret = socketpair_compat(AF_INET, SOCK_STREAM, 0, sd);
 #else
-    return socketpair(AF_UNIX, SOCK_STREAM, 0, sd);
+    int ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sd);
 #endif
+    if(ret) {
+        sd[0] = sd[1] = INVALID_SOCKET;
+    }
+    return ret;
 }
 
 int shWaitFor(shSocket *s, int op, int flags)

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -84,11 +84,15 @@ int socketpair_compat(int af, int st, int p, SOCKET sd[2])
         goto fail;
 
     /* we can't possibly succeed immediately */
-    if(connect(sd[1], &ep[0].sa, sizeof(ep[0]))!=-1)
+    if(connect(sd[1], &ep[0].sa, sizeof(ep[0]))==0) {
+        ret = -2;
         goto fail;
+    }
 
-    if(SOCKERRNO!=SOCK_EINPROGRESS)
+    if(SOCKERRNO!=SOCK_EINPROGRESS) {
+        ret = -3;
         goto fail;
+    }
 
     while(1) {
         int err;
@@ -114,8 +118,10 @@ int socketpair_compat(int af, int st, int p, SOCKET sd[2])
             continue;
         }
 
-        if(getsockopt(sd[1], SOL_SOCKET, SO_ERROR, (char*)&err, &olen))
+        if(getsockopt(sd[1], SOL_SOCKET, SO_ERROR, (char*)&err, &olen)) {
+            ret = -4;
             goto fail;
+        }
 
         if(err) {
             SOCKERRNOSET(err);

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -89,7 +89,7 @@ int socketpair_compat(int af, int st, int p, SOCKET sd[2])
         goto fail;
     }
 
-    if(SOCKERRNO!=SOCK_EINPROGRESS) {
+    if(SOCKERRNO!=SOCK_EINPROGRESS && SOCKERRNO!=SOCK_EWOULDBLOCK) {
         ret = -3;
         goto fail;
     }

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -160,9 +160,9 @@ fail:
 int shSocketPair(SOCKET sd[2])
 {
     /* Winsock doesn't provide socketpair() at all.
-     * RTEMS 4 (classic stack) provides a no-op stub
+     * RTEMS (classic stack) provides a no-op stub
      */
-#if defined(_WIN32) || defined(__rtems__)
+#if defined(_WIN32) || !defined(RTEMS_HAS_LIBBSD)
     int ret = socketpair_compat(AF_INET, SOCK_STREAM, 0, sd);
 #else
     int ret = socketpair(AF_UNIX, SOCK_STREAM, 0, sd);

--- a/client/castApp/src/sockhelpers.c
+++ b/client/castApp/src/sockhelpers.c
@@ -148,10 +148,13 @@ fail:
 
 int shSocketPair(SOCKET sd[2])
 {
-#if __unix__
-    return socketpair(AF_LOCAL, SOCK_STREAM, 0, sd);
-#else
+    /* Winsock doesn't provide socketpair() at all.
+     * RTEMS 4 (classic stack) provides a no-op stub
+     */
+#if defined(_WIN32) || defined(__rtems__)
     return socketpair_compat(AF_INET, SOCK_STREAM, 0, sd);
+#else
+    return socketpair(AF_UNIX, SOCK_STREAM, 0, sd);
 #endif
 }
 

--- a/client/castApp/src/sockhelpers.h
+++ b/client/castApp/src/sockhelpers.h
@@ -24,6 +24,27 @@
 #  define MSG_NOSIGNAL 0
 #endif
 
+/* Try to distinguish the RTEMS "classic" network stack from the newer libbsd stack
+ */
+#ifdef __rtems__
+#  include <rtems/score/cpuopts.h>
+#  if defined(RTEMS_NETWORKING)
+     /* legacy stack circa RTEMS <= 5 */
+#  else
+#    ifdef __has_include
+#      if __has_include(<rtems/rtems-net-legacy.h>)
+         /* legacy stack circa RTEMS > 5 */
+#      elif __has_include(<machine/rtems-bsd-version.h>)
+#        define RTEMS_HAS_LIBBSD
+#      else
+#        error Unexpected RTEMS configuration
+#      endif
+#    else
+#      error RTEMS < 5 needs BSP with --enable-network
+#    endif
+#  endif
+#endif /* __rtems__ */
+
 typedef struct {
     SOCKET sd; /* data socket */
     SOCKET wakeup; /* force timeout socket */

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -5,7 +5,7 @@
 
 #include "caster.h"
 
-static void testAddEnvVars(void)
+static void testAddEnvVarsX(void)
 {
     int i;
     caster_t caster;
@@ -150,7 +150,7 @@ static void testAddEnvVarsBadInput(void)
 MAIN(testAddEnvVars)
 {
     testPlan(48);
-    testAddEnvVars();
+    testAddEnvVarsX();
     testAddEnvVarsBadInput();
     return testDone();
 }

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -159,7 +159,9 @@ static void testAddEnvVarsBadInput(void)
 MAIN(testAddEnvVars)
 {
     testPlan(48);
+    osiSockAttach();
     testAddEnvVarsX();
     testAddEnvVarsBadInput();
+    osiSockRelease();
     return testDone();
 }

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -5,6 +5,8 @@
 
 #include "caster.h"
 
+void* epicsRtemsFSImage;
+
 static void testAddEnvVarsX(void)
 {
     int i;

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -7,11 +7,17 @@
 
 void* epicsRtemsFSImage;
 
+static void testLog(void* arg, struct _caster_t* self)
+{
+    testDiag("ERR %s", self->lastmsg);
+}
+
 static void testAddEnvVarsX(void)
 {
     int i;
     caster_t caster;
     casterInit(&caster);
+    caster.onmsg = &testLog;
 
     int argc;
     char *argvlist[6];
@@ -120,6 +126,7 @@ static void testAddEnvVarsBadInput(void)
 {
     caster_t caster;
     casterInit(&caster);
+    caster.onmsg = &testLog;
 
     int argc;
     char *argvlist[2];

--- a/client/castApp/src/testsock.c
+++ b/client/castApp/src/testsock.c
@@ -6,6 +6,8 @@
 
 #include "sockhelpers.h"
 
+void* epicsRtemsFSImage;
+
 static void testUDP(void)
 {
     shSocket sock[2];

--- a/client/castApp/src/testsock.c
+++ b/client/castApp/src/testsock.c
@@ -72,13 +72,15 @@ static void testWakeup(void)
     shSocket sock;
     SOCKET wakeup[2];
     epicsUInt32 junk = 0;
+    int ret;
 
     shSocketInit(&sock);
 
     sock.sd = shCreateSocket(AF_INET, SOCK_DGRAM, 0);
     testOk1(sock.sd!=INVALID_SOCKET);
 
-    testOk1(socketpair_compat(AF_INET, SOCK_STREAM, 0, wakeup)==0);
+    ret=socketpair_compat(AF_INET, SOCK_STREAM, 0, wakeup);
+    testOk(ret==0, "socketpair_compat() -> %d == 0 (%d)", ret, SOCKERRNO);
 
     sock.wakeup = wakeup[1];
 

--- a/client/castApp/src/testsock.c
+++ b/client/castApp/src/testsock.c
@@ -89,8 +89,9 @@ static void testWakeup(void)
     testOk1(sizeof(junk)==send(wakeup[0], (char*)&junk, sizeof(junk), 0));
 
     SOCKERRNOSET(0);
-    testOk1(shWaitFor(&sock, SH_CANTX, 0)==-1);
-    testOk1(SOCKERRNO==SOCK_ETIMEDOUT);
+    ret = shWaitFor(&sock, SH_CANTX, 0);
+    testOk(ret==-1 && SOCKERRNO==SOCK_ETIMEDOUT,
+           "shWaitFor(&sock, SH_CANTX, 0)==%d (%d) ==-1 (SOCK_ETIMEDOUT)", ret, (int)SOCKERRNO);
 
     epicsSocketDestroy(sock.sd);
     epicsSocketDestroy(wakeup[0]);
@@ -99,7 +100,7 @@ static void testWakeup(void)
 
 MAIN(testsock)
 {
-    testPlan(19);
+    testPlan(18);
     osiSockAttach();;
     testUDP();
     testWakeup();

--- a/client/castApp/src/testtcp.c
+++ b/client/castApp/src/testtcp.c
@@ -16,6 +16,11 @@ static epicsMutexId lock;
 
 void* epicsRtemsFSImage;
 
+static void testLog(void* arg, struct _caster_t* self)
+{
+    testDiag("MSG %s", self->lastmsg);
+}
+
 static void tester(void *raw)
 {
     caster_t *self = raw;
@@ -79,6 +84,7 @@ static void testTCP(void)
     }
 
     casterInit(&caster);
+    caster.onmsg = &testLog;
 
     memset(&dest, 0, sizeof(dest));
     dest.ia.sin_family = AF_INET;

--- a/client/castApp/src/testtcp.c
+++ b/client/castApp/src/testtcp.c
@@ -131,7 +131,7 @@ static void testTCP(void)
     ret = casterRecvPMsg(&sock, &msgid, &buf.bytes, sizeof(buf.bytes), 0);
 
     testDiag("client greeting %d", (int)ret);
-    testOk1(ret==sizeof(buf.c_greet));
+    testOk(ret==sizeof(buf.c_greet), "client greeting %d==%d", (int)ret, (int)sizeof(buf.c_greet));
 
     testOk1(msgid==0x0001);
     testOk1(buf.c_greet.version==0);

--- a/client/castApp/src/testtcp.c
+++ b/client/castApp/src/testtcp.c
@@ -14,6 +14,8 @@ static size_t cycles;
 static epicsEventId cycled[2];
 static epicsMutexId lock;
 
+void* epicsRtemsFSImage;
+
 static void tester(void *raw)
 {
     caster_t *self = raw;

--- a/client/castApp/src/testudp.c
+++ b/client/castApp/src/testudp.c
@@ -15,6 +15,8 @@ static size_t cycles;
 static epicsEventId cycled[2];
 static epicsMutexId lock;
 
+void* epicsRtemsFSImage;
+
 static void testerhook(caster_t *self, caster_h state)
 {
     if(state!=casterUDPSetup)

--- a/client/castApp/src/testudp.c
+++ b/client/castApp/src/testudp.c
@@ -17,6 +17,11 @@ static epicsMutexId lock;
 
 void* epicsRtemsFSImage;
 
+static void testLog(void* arg, struct _caster_t* self)
+{
+    testDiag("ERR %s", self->lastmsg);
+}
+
 static void testerhook(caster_t *self, caster_h state)
 {
     if(state!=casterUDPSetup)
@@ -77,6 +82,7 @@ static void testUDP(void)
     cycled[1] = epicsEventMustCreate(epicsEventEmpty);
 
     casterInit(&caster);
+    caster.onmsg = &testLog;
 
     caster.udpport = 0; /* test with random port */
     caster.testhook = &testerhook;


### PR DESCRIPTION
Support and test for non-Linux targets.  Adds testing for OSX, various RTEMS versions, and Windows.

Will use `poll()` instead of `select()` except for old windows, old RTEMS, and vxworks.

Also updates GHA configuration.