### PR TITLE
Convert to pyproject.toml and add requests dependency

### DIFF
--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -1,0 +1,27 @@
+[build-system]
+requires = ["setuptools", "setuptools-scm"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name="recceiver"
+authors = [
+    {name = "Michael Davidsaver", email = "mdavidsaver@gmail.com"},
+]
+description="resync server"
+version="1.5"
+readme = "README.rst"
+requires-python = ">=3.6"
+dependencies = [
+#    "requests",
+    "twisted",
+]
+
+[project.urls]
+Repository="https://github.com/mdavidsaver/recsync"
+
+[tool.setuptools]
+packages = ["recceiver", "twisted.plugins"]
+include-package-data = true
+
+[tool.setuptools.package-data]
+twisted = ["plugins/recceiver_plugin.py"]

--- a/server/setup.py
+++ b/server/setup.py
@@ -2,18 +2,4 @@
 
 from setuptools import setup
 
-setup(
-  name="recceiver",
-  version="1.5",
-  description="resync server",
-  author="Michael Davidsaver",
-  author_email="mdavidsaver@gmail.com",
-  url="https://github.com/mdavidsaver/recsync",
-  packages=[
-    "recceiver",
-    "twisted.plugins",
-  ],
-  package_data={
-    "twisted": ["plugins/recceiver_plugin.py"],
-  },
-)
+setup()


### PR DESCRIPTION
The previous setup.py did not list the necessary dependency `requests`.