### PR TITLE
update readfp to read_file for python 3.12

### DIFF
--- a/server/recceiver/processors.py
+++ b/server/recceiver/processors.py
@@ -69,7 +69,10 @@ class ProcessorController(service.MultiService):
         read = parser.read(map(expanduser, self.paths))
 
         if cfile:
-            parser.readfp(open(cfile,'r'))
+            if sys.version_info[0] == 3 and sys.version_info[1] > 11:
+                parser.read_file(open(cfile,'r'))
+            else:
+                parser.readfp(open(cfile,'r'))
 
         if not cfile and len(read)==0:
             # no user configuration given so load some defaults

--- a/server/recceiver/processors.py
+++ b/server/recceiver/processors.py
@@ -69,7 +69,8 @@ class ProcessorController(service.MultiService):
         read = parser.read(map(expanduser, self.paths))
 
         if cfile:
-            if sys.version_info[0] == 3 and sys.version_info[1] > 11:
+            # read_file replaced readfp in python 3.2
+            if sys.version_info[0] == 3 and sys.version_info[1] > 1:
                 parser.read_file(open(cfile,'r'))
             else:
                 parser.readfp(open(cfile,'r'))


### PR DESCRIPTION
`readfp` was depcrecated in python 3.2 and removed in python 3.12

The replacement is read_file which was introduced in python 3.2: https://docs.python.org/3/library/configparser.html#configparser.ConfigParser.read_file

This keeps things backwards compatible and but at some point we should create the last python2/3 release and then go forward with python 3 only?