### PR TITLE
Add the timezone to the time output

### DIFF
--- a/server/cf.conf
+++ b/server/cf.conf
@@ -60,3 +60,5 @@ procs = cf
 # specifying which environment VARIABLEs to pass on to the channel finder
 # and defining the corresponding PropertyName
 #environment_vars=ENGINEER:Engineer,EPICS_BASE:EpicsVersion,PWD:WorkingDirectory
+#Specify the timezone in the time output
+timezone = True

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -92,3 +92,5 @@ idkey = 42
 # specifying which environment VARIABLEs to pass on to the channel finder
 # and defining the corresponding PropertyName
 #environment_vars=ENGINEER:Engineer,EPICS_BASE:EpicsVersion,PWD:WorkingDirectory
+#Specify the timezone in the time output
+timezone = True

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -182,7 +182,7 @@ class CFProcessor(service.Service):
         iocName = TR.infos.get('IOCNAME') or TR.src.port
         hostName = TR.infos.get('HOSTNAME') or TR.src.host
         owner = TR.infos.get('ENGINEER') or TR.infos.get('CF_USERNAME') or self.conf.get('username', 'cfstore')
-        time = self.currentTime()
+        time = self.currentTime(timezone=self.conf.get('timezone', None))
 
         """The unique identifier for a particular IOC"""
         iocid = host + ":" + str(port)
@@ -540,7 +540,9 @@ def __merge_property_lists(newProperties, oldProperties):
     return newProperties
 
 
-def getCurrentTime():
+def getCurrentTime(timezone=False):
+    if timezone:
+        return str(datetime.datetime.now().astimezone())
     return str(datetime.datetime.now())
 
 


### PR DESCRIPTION
Adds the timezone to the time string on ChannelFinder updates

For example,
timezone = False time produces:
2024-05-08 12:55:18.722180
timezone = True (Berlin Time) time produces:
2024-05-08 12:55:18.722180+02:00