### PR TITLE
add iocIP prop by default, pvaPort and caPort as optional properties that default on (opt-out) 

### DIFF
--- a/server/cf.conf
+++ b/server/cf.conf
@@ -36,8 +36,8 @@ procs = cf
 
 [cf]
 # cf-store application
-# Uncomment line below to turn on the feature to add CA/PVA port info for name server to channelfinder
-# iocConnectionInfo = on
+# Uncomment line below to turn off the feature to add CA/PVA port info for name server to channelfinder
+# iocConnectionInfo = off
 # Uncomment line below to turn on the feature to add alias records to channelfinder
 # alias = on
 # Uncomment line below to turn on the feature to add EPICS record type to channelfinder

--- a/server/cf.conf
+++ b/server/cf.conf
@@ -36,6 +36,8 @@ procs = cf
 
 [cf]
 # cf-store application
+# Uncomment line below to turn on the feature to add CA/PVA port info for name server to channelfinder
+# iocConnectionInfo = on
 # Uncomment line below to turn on the feature to add alias records to channelfinder
 # alias = on
 # Uncomment line below to turn on the feature to add EPICS record type to channelfinder

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -68,8 +68,8 @@ idkey = 42
 
 [cf]
 # cf-store application
-# Uncomment line below to turn on the feature to add CA/PVA port info for name server to channelfinder
-# iocConnectionInfo = on
+# Uncomment line below to turn off the feature to add CA/PVA port info for name server to channelfinder
+# iocConnectionInfo = off
 # Uncomment line below to turn on the feature to add alias records to channelfinder
 # alias = on
 # Uncomment line below to turn on the feature to add EPICS record type to channelfinder

--- a/server/demo.conf
+++ b/server/demo.conf
@@ -68,6 +68,8 @@ idkey = 42
 
 [cf]
 # cf-store application
+# Uncomment line below to turn on the feature to add CA/PVA port info for name server to channelfinder
+# iocConnectionInfo = on
 # Uncomment line below to turn on the feature to add alias records to channelfinder
 # alias = on
 # Uncomment line below to turn on the feature to add EPICS record type to channelfinder

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -76,7 +76,8 @@ class CFProcessor(service.Service):
             self.client = ChannelFinderClient()
             try:
                 cf_props = [prop['name'] for prop in self.client.getAllProperties()]
-                reqd_props = {'hostName', 'iocName', 'pvStatus', 'time', 'iocid', RECCEIVERID_KEY}
+                reqd_props = {'hostName', 'iocName', 'pvStatus', 'time', 'iocid', 'iocIP', RECCEIVERID_KEY}
+
                 if (self.conf.get('alias', 'default') == 'on'):
                     reqd_props.add('alias')
                 if (self.conf.get('recordType', 'default') == 'on'):
@@ -88,6 +89,13 @@ class CFProcessor(service.Service):
                     self.env_vars = { k.strip():v.strip() for k, v in env_vars_dict.items()}
                     for epics_env_var_name, cf_prop_name in self.env_vars.items():
                         reqd_props.add(cf_prop_name)
+                # Standard property names for CA/PVA name server connections. These are
+                # environment variables from reccaster so take advantage of env_vars
+                if self.conf.get('iocConnectionInfo', 'default') == 'on':
+                    self.env_vars["RSRV_SERVER_PORT"] = "caPort"
+                    self.env_vars["PVAS_SERVER_PORT"] = "pvaPort"
+                    reqd_props.add("caPort")
+                    reqd_props.add("pvaPort")
                 wl = self.conf.get('infotags', list())
                 if wl:
                     whitelist = [s.strip(', ') for s in wl.split()]
@@ -236,7 +244,7 @@ class CFProcessor(service.Service):
 
         if TR.initial:
             """Add IOC to source list """
-            self.iocs[iocid] = {"iocname": iocName, "hostname": hostName, "owner": owner, "time": time,
+            self.iocs[iocid] = {"iocname": iocName, "hostname": hostName, "iocIP": host, "owner": owner, "time": time,
                                 "channelcount": 0}
         if not TR.connected:
             delrec.extend(self.channel_dict.keys())
@@ -257,7 +265,7 @@ class CFProcessor(service.Service):
                     if pv in pvInfoByName and "aliases" in pvInfoByName[pv]:
                         for a in pvInfoByName[pv]["aliases"]:
                             self.remove_channel(a, iocid)
-        poll(__updateCF__, self, pvInfoByName, delrec, hostName, iocName, iocid, owner, time)
+        poll(__updateCF__, self, pvInfoByName, delrec, hostName, iocName, host, iocid, owner, time)
         dict_to_file(self.channel_dict, self.iocs, self.conf)
 
     def remove_channel(self, a, iocid):
@@ -321,7 +329,7 @@ def dict_to_file(dict, iocs, conf):
             json.dump(list, f)
 
 
-def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, iocTime):
+def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocIP, iocid, owner, iocTime):
     _log.info("CF Update IOC: {iocid}", iocid=iocid)
 
     # Consider making this function a class methed then 'proc' simply becomes 'self'
@@ -337,6 +345,7 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
         iocName = iocs[iocid]["iocname"]
         owner = iocs[iocid]["owner"]
         iocTime = iocs[iocid]["time"]
+        iocIP = iocs[iocid]["iocIP"]
     else:
         _log.warn('IOC Env Info not found: {iocid}', iocid=iocid)
 
@@ -457,7 +466,7 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
             raise defer.CancelledError()
 
     for pv in new:
-        newProps = create_properties(owner, iocTime, recceiverid, hostName, iocName, iocid)
+        newProps = create_properties(owner, iocTime, recceiverid, hostName, iocName, iocIP, iocid)
         if (conf.get('recordType', 'default') == 'on'):
             newProps.append({u'name': 'recordType', u'owner': owner, u'value': pvInfoByName[pv]['recordType']})
         if pv in pvInfoByName and "infoProperties" in pvInfoByName[pv]:
@@ -511,11 +520,12 @@ def __updateCF__(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, io
     if proc.cancelled:
         raise defer.CancelledError()
 
-def create_properties(owner, iocTime, recceiverid, hostName, iocName, iocid):
+def create_properties(owner, iocTime, recceiverid, hostName, iocName, iocIP, iocid):
     return [
                         {u'name': 'hostName', u'owner': owner, u'value': hostName},
                         {u'name': 'iocName', u'owner': owner, u'value': iocName},
                         {u'name': 'iocid', u'owner': owner, u'value': iocid},
+                        {u'name': 'iocIP', u'owner': owner, u'value': iocIP},
                         {u'name': 'pvStatus', u'owner': owner, u'value': 'Active'},
                         {u'name': 'time', u'owner': owner, u'value': iocTime},
                         {u'name': RECCEIVERID_KEY, u'owner': owner, u'value': recceiverid}]
@@ -553,13 +563,13 @@ def prepareFindArgs(conf, args):
     return args
 
 
-def poll(update, proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, iocTime):
+def poll(update, proc, pvInfoByName, delrec, hostName, iocName, iocIP, iocid, owner, iocTime):
     _log.info("Polling {iocName} begins...", iocName=iocName)
     sleep = 1
     success = False
     while not success:
         try:
-            update(proc, pvInfoByName, delrec, hostName, iocName, iocid, owner, iocTime)
+            update(proc, pvInfoByName, delrec, hostName, iocName, iocIP, iocid, owner, iocTime)
             success = True
             return success
         except RequestException as e:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -91,7 +91,7 @@ class CFProcessor(service.Service):
                         reqd_props.add(cf_prop_name)
                 # Standard property names for CA/PVA name server connections. These are
                 # environment variables from reccaster so take advantage of env_vars
-                if self.conf.get('iocConnectionInfo', 'default') == 'on':
+                if self.conf.get('iocConnectionInfo', 'default') == 'off':
                     self.env_vars["RSRV_SERVER_PORT"] = "caPort"
                     self.env_vars["PVAS_SERVER_PORT"] = "pvaPort"
                     reqd_props.add("caPort")

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -91,7 +91,7 @@ class CFProcessor(service.Service):
                         reqd_props.add(cf_prop_name)
                 # Standard property names for CA/PVA name server connections. These are
                 # environment variables from reccaster so take advantage of env_vars
-                if self.conf.get('iocConnectionInfo', 'default') == 'off':
+                if self.conf.get('iocConnectionInfo', 'default') != 'off':
                     self.env_vars["RSRV_SERVER_PORT"] = "caPort"
                     self.env_vars["PVAS_SERVER_PORT"] = "pvaPort"
                     reqd_props.add("caPort")


### PR DESCRIPTION
Addresses this issue ticket https://github.com/ChannelFinder/recsync/issues/90

Adds a new default property `iocIP` and adds a new preference settings `iocConnectionInfo` which defaults to on. If this property is enabled, the other two port properties will also be sent to channel finder - `pvaPort` and `caPort`. A user who does not want these properties can toggle `iocConnectionInfo` to off.

In the case reccaster or EPICS base is an older version that does not support RSRV_SERVER_PORT or PVAS_SERVER_PORT (or QSRV is not enabled), recceiver will just skip adding this property to the channel.

```
2024-06-14T13:49:17-0400 [recceiver.cfstore#debug] EPICS environment var RSRV_SERVER_PORT listed in environment_vars setting list not found in this IOC: test-
ioc
2024-06-14T13:49:17-0400 [recceiver.cfstore#debug] EPICS environment var PVAS_SERVER_PORT listed in environment_vars setting list not found in this IOC: test-
ioc
``` 