### PR TITLE
Defer importing `twisted.internet.reactor`, fixes "reactor already installed"

### DIFF
--- a/server/recceiver/announce.py
+++ b/server/recceiver/announce.py
@@ -3,7 +3,7 @@
 import sys
 import struct
 
-from twisted.internet import protocol, reactor
+from twisted.internet import protocol
 from twisted.logger import Logger
 
 _log = Logger(__name__)
@@ -14,12 +14,14 @@ _Ann = struct.Struct('>HH4sHHI')
 __all__ = ['Announcer']
 
 class Announcer(protocol.DatagramProtocol):
-    reactor = reactor
-
     def __init__(self, tcpport, key=0,
                  tcpaddr='\xff\xff\xff\xff',
                  udpaddrs=[('<broadcast>',5049)],
                  period=15.0):
+        from twisted.internet import reactor
+
+        self.reactor = reactor
+
         if sys.version_info[0] < 3:
             self.msg = _Ann.pack(0x5243, 0, tcpaddr, tcpport, 0, key)
         else:

--- a/server/recceiver/application.py
+++ b/server/recceiver/application.py
@@ -7,7 +7,7 @@ from zope.interface import implementer
 
 from twisted import plugin
 from twisted.python import usage, log
-from twisted.internet import reactor, defer
+from twisted.internet import defer
 from twisted.internet.error import CannotListenError
 from twisted.application import service
 from twisted.logger import Logger
@@ -31,9 +31,12 @@ class Log2Twisted(logging.StreamHandler):
         pass
 
 class RecService(service.MultiService):
-    reactor = reactor
 
     def __init__(self, config):
+        from twisted.internet import reactor
+
+        self.reactor = reactor
+
         service.MultiService.__init__(self)
         self.annperiod = float(config.get('announceInterval', '15.0'))
         self.tcptimeout = float(config.get('tcptimeout', '15.0'))

--- a/server/recceiver/recast.py
+++ b/server/recceiver/recast.py
@@ -12,7 +12,6 @@ import struct, collections, random, sys
 from twisted.protocols import stateful
 from twisted.internet import defer
 from twisted.internet import protocol
-from twisted.internet import reactor
 
 from .interfaces import ITransaction
 
@@ -38,11 +37,14 @@ assert _c_rec.size==8
 
 class CastReceiver(stateful.StatefulProtocol):
 
-    reactor = reactor
     timeout = 3.0
     version = 0
 
     def __init__(self, active=True):
+        from twisted.internet import reactor
+
+        self.reactor = reactor
+
         self.sess, self.active = None, active
         self.uploadSize, self.uploadStart = 0, 0
 
@@ -232,10 +234,12 @@ class Transaction(object):
 class CollectionSession(object):
     timeout = 5.0
     trlimit = 0
-    reactor = reactor
 
     def __init__(self, proto, endpoint):
+        from twisted.internet import reactor
+
         _log.info("Open session from {endpoint}",endpoint=endpoint)
+        self.reactor = reactor
         self.proto, self.ep = proto, endpoint
         self.TR = Transaction(self.ep, id(self))
         self.TR.initial = True

--- a/server/recceiver/udpbcast.py
+++ b/server/recceiver/udpbcast.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from twisted.internet import udp, reactor
+from twisted.internet import udp
 from twisted.application import internet
 
 __all__ = ['SharedUDP','SharedUDPServer']
@@ -29,6 +29,8 @@ class SharedUDPServer(internet.UDPServer):
     """A UDP server using SharedUDP
     """
     def _getPort(self):
+        from twisted.internet import reactor
+
         R = getattr(self, 'reactor', reactor)
         port = SharedUDP(reactor=R, *self.args, **self.kwargs)
         port.startListening()


### PR DESCRIPTION
While running RecCeiver with 24.3.0, I found the same issue as #37:

    The specified reactor cannot be used, failed with error: reactor already installed.

but initializing a `dropin.cache` did not work out for me. After some research, I found scrapy's asyncio documentation:

https://docs.scrapy.org/en/latest/topics/asyncio.html#handling-a-pre-installed-reactor

Turns out importing `twisted.internet.reactor` initializes a default reactor, which makes it impossible to change the reactor in the command-line (`-r` option).

So this PR defers importing reactor, which makes RecCeiver work for me.

This PR was only crudely tested, by seeing that the application doesn't crash.