### PR TITLE
Remove min function call from debug statement in the clean service function

### DIFF
--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -318,7 +318,7 @@ class CFProcessor(service.Service):
         for ch in channels or []:
             new_channels.append(ch[u'name'])
         _log.info("Total channels to update: {nChannels}", nChannels=len(new_channels))
-        _log.debug('Update "pvStatus" property to "Inactive" for {n_channels} channels', n_channels=min(len(new_channels), self.conf["findSizeLimit"]))
+        _log.debug('Update "pvStatus" property to "Inactive" for {n_channels} channels', n_channels=len(new_channels))
         self.client.update(property={u'name': 'pvStatus', u'owner': owner, u'value': "Inactive"},
                                         channelNames=new_channels)
 


### PR DESCRIPTION
@jacomago I ran into this log statement which was causing a runtime error when `findSizeLimit` wasn't defined in my configuration file.

First I was going to change this to `self.conf.get` but then it seemed like this isn't necessary here? Since `get_active_channels` is already called and it's returned value is the `channels` arg in `clean_channels`?