### PR TITLE
Switch from twisted logging back to python logging module

### DIFF
--- a/server/recceiver/announce.py
+++ b/server/recceiver/announce.py
@@ -4,9 +4,9 @@ import sys
 import struct
 
 from twisted.internet import protocol
-from twisted.logger import Logger
+import logging
 
-_log = Logger(__name__)
+_log = logging.getLogger(__name__)
 
 
 _Ann = struct.Struct('>HH4sHHI')
@@ -53,14 +53,14 @@ class Announcer(protocol.DatagramProtocol):
         self.D = self.reactor.callLater(self.delay, self.sendOne)
         for A in self.udps:
             try:
-                _log.debug('announce to {s}',s=A)
+                _log.debug('announce to {s}'.format(s=A))
                 self.transport.write(self.msg, A)
                 try:
                     self.udpErr.remove(A)
-                    _log.warn('announce OK to {s}',s=A)
+                    _log.warning('announce OK to {s}'.format(s=A))
                 except KeyError:
                     pass
             except:
                 if A not in self.udpErr:
                     self.udpErr.add(A)
-                    _log.exception('announce Error to {s}',s=A)
+                    _log.exception('announce Error to {s}'.format(s=A))

--- a/server/recceiver/application.py
+++ b/server/recceiver/application.py
@@ -10,14 +10,13 @@ from twisted.python import usage, log
 from twisted.internet import defer
 from twisted.internet.error import CannotListenError
 from twisted.application import service
-from twisted.logger import Logger
 
 from .recast import CastFactory
 from .udpbcast import SharedUDP
 from .announce import Announcer
 from .processors import ProcessorController
 
-_log = Logger(__name__)
+_log = logging.getLogger(__name__)
 
 class Log2Twisted(logging.StreamHandler):
     """Print logging module stream to the twisted log
@@ -90,7 +89,7 @@ class RecService(service.MultiService):
 
         # Find out which port is in use
         addr = self.tcp.getHost()
-        _log.info('RecService listening on {addr}', addr=addr)
+        _log.info('RecService listening on {addr}'.format(addr=addr))
 
         self.key = random.randint(0,0xffffffff)
 
@@ -138,7 +137,7 @@ class Maker(object):
         lvlname = conf.get('loglevel', 'WARN')
         lvl = logging.getLevelName(lvlname)
         if not isinstance(lvl, (int, )):
-            print("Invalid loglevel", lvlname)
+            print("Invalid loglevel {}. Setting to WARN level instead.".format(lvlname))
             lvl = logging.WARN
 
         fmt = conf.get('logformat', "%(levelname)s:%(name)s %(message)s")

--- a/server/recceiver/dbstore.py
+++ b/server/recceiver/dbstore.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import itertools
-from twisted.logger import Logger
+import logging
 
 from zope.interface import implementer
 
@@ -11,7 +11,7 @@ from twisted.enterprise import adbapi as db
 
 from . import interfaces
 
-_log = Logger(__name__)
+_log = logging.getLogger(__name__)
 
 __all__  = ['DBProcessor']
 

--- a/server/recceiver/processors.py
+++ b/server/recceiver/processors.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from twisted.logger import Logger
+import logging
 import sys
 
 from zope.interface import implementer
@@ -17,7 +17,7 @@ from twisted.internet import task
 from twisted.application import service
 
 from . import interfaces
-_log = Logger(__name__)
+_log = logging.getLogger(__name__)
 
 __all__ = [
     'ShowProcessor',
@@ -77,7 +77,7 @@ class ProcessorController(service.MultiService):
         plugs = {}
 
         for plug in plugin.getPlugins(interfaces.IProcessorFactory):
-            _log.debug('Available plugin: {name}', name=plug.name)
+            _log.debug('Available plugin: {name}'.format(name=plug.name))
             plugs[plug.name] = plug
 
         self.procs = []
@@ -109,13 +109,13 @@ class ProcessorController(service.MultiService):
 
         def punish(err, B):
             if err.check(defer.CancelledError):
-                _log.debug('Cancel processing: {name}: {trans}', name=B.name, trans=trans)
+                _log.debug('Cancel processing: {name}: {trans}'.format(name=B.name, trans=trans))
                 return err
             try:
                 self.procs.remove(B)
-                _log.error('Remove processor: {name}: {err}', name=B.name, err=err)
+                _log.error('Remove processor: {name}: {err}'.format(name=B.name, err=err))
             except:
-                _log.debug('Remove processor: {name}: aleady removed', name=B.name)
+                _log.debug('Remove processor: {name}: aleady removed'.format(name=B.name))
             return err
 
         defers = [ defer.maybeDeferred(P.commit, trans).addErrback(punish, P) for P in self.procs ]
@@ -136,7 +136,7 @@ class ShowProcessor(service.Service):
 
     def startService(self):
         service.Service.startService(self)
-        _log.info("Show processor '{processor}' starting", processor=self.name)
+        _log.info("Show processor '{processor}' starting".format(processor=self.name))
 
     def commit(self, transaction):
 
@@ -162,25 +162,25 @@ class ShowProcessor(service.Service):
 
 
     def _commit(self, trans):
-        _log.debug("# Show processor '{name}' commit", name=self.name)
-        _log.info("# From {host}:{port}", host=trans.src.host,port=trans.src.port)
+        _log.debug("# Show processor '{name}' commit".format(name=self.name))
+        _log.info("# From {host}:{port}".format(host=trans.src.host,port=trans.src.port))
         if not trans.connected:
             _log.info("#  connection lost")
         for item in trans.infos.items():
-            _log.info(" epicsEnvSet('{name}','{value}')", name=item[0], value=item[1])
+            _log.info(" epicsEnvSet('{name}','{value}')".format(name=item[0], value=item[1]))
         for rid, (rname, rtype) in trans.addrec.items():
-            _log.info(" record({rtype}, \"{rname}\") {", rtype=rtype, rname=rname)
+            _log.info(" record({rtype}, \"{rname}\") {{".format(rtype=rtype, rname=rname))
             for alias in trans.aliases.get(rid, []):
-                _log.info("  alias(\"{alias}\")", alias=alias)
+                _log.info("  alias(\"{alias}\")".format(alias=alias))
             for item in trans.recinfos.get(rid, {}).items():
-                _log.info("  info({name},\"{value}\")", name=item[0], value=[1])
+                _log.info("  info({name},\"{value}\")".format(name=item[0], value=[1]))
             _log.info(" }")
             yield
         _log.info("# End")
 
     def stopService(self):
         service.Service.stopService(self)
-        _log.info("Show processor '{name}' stopping", name=self.name)
+        _log.info("Show processor '{name}' stopping".format(name=self.name))
 
 
 @implementer(plugin.IPlugin, interfaces.IProcessorFactory)

--- a/server/recceiver/recast.py
+++ b/server/recceiver/recast.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
-from twisted.logger import Logger
-_log = Logger(__name__)
+import logging
+_log = logging.getLogger(__name__)
 
 import sys, time
 
@@ -109,7 +109,7 @@ class CastReceiver(stateful.StatefulProtocol):
         self.restartPingTimer()
         magic, msgid, blen = _Head.unpack(data)
         if magic!=_M:
-            _log.error('Protocol error! Bad magic {magic}',magic=magic)
+            _log.error('Protocol error! Bad magic {magic}'.format(magic=magic))
             self.transport.loseConnection()
             return
         self.msgid = msgid
@@ -123,7 +123,7 @@ class CastReceiver(stateful.StatefulProtocol):
     def recvClientGreeting(self, body):
         cver, ctype, skey = _c_greet.unpack(body[:_c_greet.size])
         if ctype!=0:
-            _log.error("I don't understand you! {s}", s=ctype)
+            _log.error("I don't understand you! {s}".format(s=ctype))
             self.transport.loseConnection()
             return
         self.version = min(self.version, cver)
@@ -135,7 +135,7 @@ class CastReceiver(stateful.StatefulProtocol):
     def recvPong(self, body):
         nonce, = _ping.unpack(body[:_ping.size])
         if nonce != self.nonce:
-            _log.error('pong nonce does not match! {pong_nonce}!={nonce}',pong_nonce=nonce,nonce=self.nonce)
+            _log.error('pong nonce does not match! {pong_nonce}!={nonce}'.format(pong_nonce=nonce,nonce=self.nonce))
             self.transport.loseConnection()
         else:
             _log.debug('pong nonce match')
@@ -194,7 +194,7 @@ class CastReceiver(stateful.StatefulProtocol):
         size_kb = self.uploadSize / 1024
         rate_kbs = size_kb / elapsed_s
         src = "{}:{}".format(self.sess.ep.host, self.sess.ep.port)
-        _log.info('Done message from {src}: uploaded {size_kb}kB in {elapsed_s}s ({rate_kbs}kB/s)', src=src, size_kb=size_kb, elapsed_s=elapsed_s, rate_kbs=rate_kbs)
+        _log.info('Done message from {src}: uploaded {size_kb}kB in {elapsed_s}s ({rate_kbs}kB/s)'.format(src=src, size_kb=size_kb, elapsed_s=elapsed_s, rate_kbs=rate_kbs))
 
         return self.getInitialState()
 
@@ -238,7 +238,7 @@ class CollectionSession(object):
     def __init__(self, proto, endpoint):
         from twisted.internet import reactor
 
-        _log.info("Open session from {endpoint}",endpoint=endpoint)
+        _log.info("Open session from {endpoint}".format(endpoint=endpoint))
         self.reactor = reactor
         self.proto, self.ep = proto, endpoint
         self.TR = Transaction(self.ep, id(self))
@@ -248,7 +248,7 @@ class CollectionSession(object):
         self.dirty = False
 
     def close(self):
-        _log.info("Close session from {ep}", ep=self.ep)
+        _log.info("Close session from {ep}".format(ep=self.ep))
 
         def suppressCancelled(err):
             if not err.check(defer.CancelledError):
@@ -265,7 +265,7 @@ class CollectionSession(object):
         self.flush()
 
     def flush(self, connected=True):
-        _log.info("Flush session from {s}", s=self.ep)
+        _log.info("Flush session from {s}".format(s=self.ep))
         self.T = None
         if not self.dirty:
             return
@@ -274,15 +274,15 @@ class CollectionSession(object):
         self.dirty = False
 
         def commit(_ignored):
-            _log.info('Commit: {TR}', TR=TR)
+            _log.info('Commit: {TR}'.format(TR=TR))
             return defer.maybeDeferred(self.factory.commit, TR)
 
         def abort(err):
             if err.check(defer.CancelledError):
-                _log.info('Commit cancelled: {TR}', TR=TR)
+                _log.info('Commit cancelled: {TR}'.format(TR=TR))
                 return err
             else:
-                _log.error('Commit failure: {err}', err=err)
+                _log.error('Commit failure: {err}'.format(err=err))
                 self.proto.transport.loseConnection()
                 raise defer.CancelledError()
 


### PR DESCRIPTION
This addresses https://github.com/ChannelFinder/recsync/issues/96

I've tried to get twisted logging to use the conf file loglevel but it hasn't been successful. These attempts mostly revolved around adding this logic to application.py

```python
...

class LogLevelFilter(object):
    def __init__(self, level):
        self.level = level

    def __call__(self, event):
        return event if event.get('log_level') >= self.level else None

...

@implementer(service.IServiceMaker, plugin.IPlugin)
class Maker(object):

...

    lvlname = conf.get('loglevel', 'WARN')
    if lvlname == 'DEBUG':
        lvl = LogLevel.debug
    elif lvlname == 'INFO':
        lvl = LogLevel.info
    elif lvlname == 'WARN':
        lvl = LogLevel.warn
    elif lvlname == 'ERROR':
        lvl = LogLevel.error
    elif lvlname == 'CRITICAL':
        lvl = LogLevel.critical
    else:
        print("Invalid loglevel {}. Will default to level WARN".format(lvlname))
        lvl = LogLevel.warn

    globalLogPublisher.addObserver(LogLevelFilter(lvl))
...
```

It works fine for some log messages but certain log messages like ` _log.debug('announce to {s}'.format(s=A))`  show up in the logs no matter what. So I suggest we revert back to the python logging module unless someone else can figure out the twisted logging since IMO this issue is a blocker to creating a new release.