### PR TITLE
Re-enable checks for cf conf keys to be set to on

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -69,6 +69,7 @@
 #infotags = archive foo bar blah
 
 # Uncomment line below to turn off the feature to add CA/PVA port info for name server to channelfinder
+# By default this is enabled
 #iocConnectionInfo = off
 
 # Uncomment line below to turn on the feature to add alias records to channelfinder


### PR DESCRIPTION
Version 1.7 of recsync changed how the CF configuration settings work. Now if you set `recordDesc`, `recordType`, `iocConnectionInfo`, or `alias` in the cf.conf file then they automatically are enabled. The code doesn't check if the setting is "on" or "off". In addition `iocConnectionInfo` was supposed to be on by default but with this change now you have to define it in the configuration file.

This adds back the checks for these properties and forces the user to set `recordDesc`, `alias`, and `recordType` explicitly to "on" like before.