### PR TITLE
switch type hints to be py36 compatible

### DIFF
--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -14,15 +14,27 @@ on:
 jobs:
   build-server:
     runs-on: ubuntu-latest
+    container: ${{ matrix.container }}
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
+        include:
+          - python-version: "3.6"
+            container: "python:3.6"
+          - python-version: "3.7"
+            container: "python:3.7"
+          - python-version: "3.8"
+          - python-version: "3.9"
+          - python-version: "3.10"
+          - python-version: "3.11"
+          - python-version: "3.12"
+          - python-version: "3.13"
     defaults:
         run:
             working-directory: server
     steps:
         - uses: actions/checkout@v4
         - name: Set up Python ${{ matrix.python-version }}
+          if: ${{ !matrix.container }}
           uses: actions/setup-python@v5
           with:
             python-version: ${{ matrix.python-version }}

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -8,6 +8,7 @@ import socket
 import time
 from collections import defaultdict
 from operator import itemgetter
+from typing import Dict, List, Set
 
 from channelfinder import ChannelFinderClient
 from requests import ConnectionError, RequestException
@@ -397,7 +398,7 @@ def dict_to_file(dict, iocs, conf):
             json.dump(list, f)
 
 
-def create_channel(name: str, owner: str, properties: list[dict[str, str]]):
+def create_channel(name: str, owner: str, properties: List[Dict[str, str]]):
     return {
         "name": name,
         "owner": owner,
@@ -405,7 +406,7 @@ def create_channel(name: str, owner: str, properties: list[dict[str, str]]):
     }
 
 
-def create_property(owner: str, name: str, value: str):
+def create_property(owner: str, name: str, value: str) -> Dict[str, str]:
     return {
         "name": name,
         "owner": owner,
@@ -741,8 +742,8 @@ def create_default_properties(owner, iocTime, recceiverid, channels_dict, iocs, 
 
 
 def __merge_property_lists(
-    newProperties: list[dict[str, str]], channel: dict[str, list[dict[str, str]]], managed_properties=set()
-) -> list[dict[str, str]]:
+    newProperties: List[Dict[str, str]], channel: Dict[str, List[Dict[str, str]]], managed_properties: Set[str] = set()
+) -> List[Dict[str, str]]:
     """
     Merges two lists of properties ensuring that there are no 2 properties with
     the same name In case of overlap between the new and old property lists the


### PR DESCRIPTION
https://github.com/ChannelFinder/recsync/pull/105 added some type hint syntax which is only available on python 3.9+ . This updates it to be backward compatible to the target 3.6 version

Also added 3.6 and 3.7 to the CI with a docker container since there aren't any ubuntu runners that support python < 3.8  - https://github.com/actions/setup-python/issues/1048 . And added 3.13 to the build-server CI

~~I'm not sure why the CI for the container tests are failing and if it's related to this or not.~~ Re-ran the failed tests and it worked