### PR TITLE
Chunk the calls to ChannelFinder

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -80,7 +80,8 @@
 # Uncomment line below to turn on the feature to add description field to channelfinder
 #recordDesc = True
 
-# The size limit for finding channels (ie the value of the '~size' query parameter)
+# The size limit for finding channels and submitting channels
+# (ie the value of the '~size' query parameter)
 # If not specified then the fallback is the server default
 #findSizeLimit = 10000
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -709,12 +709,18 @@ def __updateCF__(
                         _log.debug("Add new alias: {s}".format(s=channels[-1]))
     _log.info("Total channels to update: {nChannels} {iocName}".format(nChannels=len(channels), iocName=iocName))
     if len(channels) != 0:
-        client.set(channels=channels)
+        cf_set_chunked(client, channels, conf.get("findSizeLimit", 10000))
     else:
         if old_channels and len(old_channels) != 0:
-            client.set(channels=channels)
+            cf_set_chunked(client, channels, conf.get("findSizeLimit", 10000))
     if processor.cancelled:
         raise defer.CancelledError()
+
+
+def cf_set_chunked(client, channels, chunk_size=10000):
+    for i in range(0, len(channels), chunk_size):
+        chunk = channels[i : i + chunk_size]
+        client.set(channels=chunk)
 
 
 def create_properties(owner, iocTime, recceiverid, hostName, iocName, iocIP, iocid):


### PR DESCRIPTION
This solves an issue we had here with a 170 000 PV IOC where the ChannelFinder errored out.