### PR TITLE
Convert addReccasterEnvVars to linked list and create helper function for addReccaster* logic

### DIFF
--- a/client/castApp/src/Makefile
+++ b/client/castApp/src/Makefile
@@ -45,6 +45,7 @@ TESTS += testtcp
 
 TESTPROD_HOST += testAddEnvVars
 testAddEnvVars_SRCS += testAddEnvVars.c
+testAddEnvVars_SRCS += dbcb.c
 testAddEnvVars_SYS_LIBS_WIN32 = ws2_32
 TESTS += testAddEnvVars
 

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -114,6 +114,7 @@ void casterInit(caster_t *self)
     self->onmsg = &casterShowMsgDefault;
     self->current = casterStateInit;
     self->timeout = reccastTimeout;
+    ellInit(&self->extra_envs);
     ellInit(&self->exclude_patterns);
 
     if(shSocketPair(self->wakeup))
@@ -122,7 +123,6 @@ void casterInit(caster_t *self)
 
 void casterShutdown(caster_t *self)
 {
-    int i;
     epicsUInt32 junk = htonl(0xdeadbeef);
 
     epicsMutexMustLock(self->lock);
@@ -137,10 +137,7 @@ void casterShutdown(caster_t *self)
     epicsEventMustWait(self->shutdownEvent);
 
     epicsMutexMustLock(self->lock);
-    for (i = 0; i < self->num_extra_envs; i++) {
-        free(self->extra_envs[i]);
-    }
-    free(self->extra_envs);
+    ellFree2(&self->extra_envs, &nodeFree);
     epicsMutexUnlock(self->lock);
 
     epicsMutexMustLock(self->lock);

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -7,6 +7,7 @@
 #include <epicsAssert.h>
 #include <epicsThread.h>
 #include <epicsStdio.h>
+#include <cantProceed.h>
 
 #define epicsExportSharedSymbols
 
@@ -114,8 +115,11 @@ void casterInit(caster_t *self)
     self->onmsg = &casterShowMsgDefault;
     self->current = casterStateInit;
     self->timeout = reccastTimeout;
-    ellInit(&self->extra_envs);
+    ellInit(&self->envs);
     ellInit(&self->exclude_patterns);
+
+    /* add default_envs to envs list which can be expanded by the user with addReccasterEnvVars iocsh function */
+    addToReccasterLinkedList(self, default_envs_count, default_envs, &self->envs, "casterInit", "Default environment variable");
 
     if(shSocketPair(self->wakeup))
         errlogPrintf("Error: casterInit failed to create shutdown socket: %d\n", SOCKERRNO);
@@ -137,7 +141,7 @@ void casterShutdown(caster_t *self)
     epicsEventMustWait(self->shutdownEvent);
 
     epicsMutexMustLock(self->lock);
-    ellFree(&self->extra_envs);
+    ellFree(&self->envs);
     ellFree(&self->exclude_patterns);
     epicsMutexUnlock(self->lock);
 

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -7,7 +7,6 @@
 #include <epicsAssert.h>
 #include <epicsThread.h>
 #include <epicsStdio.h>
-#include <cantProceed.h>
 
 #define epicsExportSharedSymbols
 

--- a/client/castApp/src/caster.c
+++ b/client/castApp/src/caster.c
@@ -137,10 +137,7 @@ void casterShutdown(caster_t *self)
     epicsEventMustWait(self->shutdownEvent);
 
     epicsMutexMustLock(self->lock);
-    ellFree2(&self->extra_envs, &nodeFree);
-    epicsMutexUnlock(self->lock);
-
-    epicsMutexMustLock(self->lock);
+    ellFree(&self->extra_envs);
     ellFree(&self->exclude_patterns);
     epicsMutexUnlock(self->lock);
 

--- a/client/castApp/src/caster.h
+++ b/client/castApp/src/caster.h
@@ -74,8 +74,7 @@ typedef struct _caster_t {
     int shutdown;
     char lastmsg[MAX_STRING_SIZE];
 
-    char **extra_envs;
-    int num_extra_envs;
+    ELLLIST extra_envs;
 
     ELLLIST exclude_patterns;
 

--- a/client/castApp/src/caster.h
+++ b/client/castApp/src/caster.h
@@ -22,6 +22,7 @@ epicsShareExtern double reccastTimeout;
 epicsShareExtern double reccastMaxHoldoff;
 
 extern const char* default_envs[];
+extern const size_t default_envs_count;
 
 typedef enum {
   casterUDPSetup,
@@ -74,8 +75,7 @@ typedef struct _caster_t {
     int shutdown;
     char lastmsg[MAX_STRING_SIZE];
 
-    ELLLIST extra_envs;
-
+    ELLLIST envs;
     ELLLIST exclude_patterns;
 
 } caster_t;
@@ -104,6 +104,9 @@ int casterSendInfo(caster_t *c, ssize_t rid, const char* name, const char* val);
 /* push process database information */
 epicsShareFunc
 int casterPushPDB(void *junk, caster_t *caster);
+
+epicsShareFunc
+void addToReccasterLinkedList(caster_t* self, size_t itemCount, const char **items, ELLLIST* reccastList, const char* funcName, const char* itemDesc);
 
 epicsShareFunc
 void addReccasterEnvVars(caster_t* self, int argc, char **argv);

--- a/client/castApp/src/caster.h
+++ b/client/castApp/src/caster.h
@@ -106,13 +106,13 @@ epicsShareFunc
 int casterPushPDB(void *junk, caster_t *caster);
 
 epicsShareFunc
-void addToReccasterLinkedList(caster_t* self, size_t itemCount, const char **items, ELLLIST* reccastList, const char* funcName, const char* itemDesc);
+int addToReccasterLinkedList(caster_t* self, size_t itemCount, const char **items, ELLLIST* reccastList, const char* funcName, const char* itemDesc);
 
 epicsShareFunc
-void addReccasterEnvVars(caster_t* self, int argc, char **argv);
+int addReccasterEnvVars(caster_t* self, int argc, char **argv);
 
 epicsShareFunc
-void addReccasterExcludePattern(caster_t* self, int argc, char **argv);
+int addReccasterExcludePattern(caster_t* self, int argc, char **argv);
 
 /* internal */
 

--- a/client/castApp/src/castinit.c
+++ b/client/castApp/src/castinit.c
@@ -82,7 +82,6 @@ static void casthook(initHookState state)
 void addReccasterEnvVars(caster_t* self, int argc, char **argv)
 {
     size_t i, j;
-    int ret = 0;
 
     argv++; argc--; /* skip function arg */
     if(argc < 1) {
@@ -103,91 +102,54 @@ void addReccasterEnvVars(caster_t* self, int argc, char **argv)
         epicsMutexUnlock(self->lock);
         return;
     }
-    int new_extra_envs_size = self->num_extra_envs + argc;
-    int num_new_extra_envs = self->num_extra_envs;
 
-    char **new_extra_envs = calloc(new_extra_envs_size, sizeof(*new_extra_envs));
-    if(new_extra_envs == NULL) {
-        errlogSevPrintf(errlogMajor, "Error in memory allocation of new_extra_envs from addReccasterEnvVars\n");
-        epicsMutexUnlock(self->lock);
-        return;
-    }
-    /* copy self->extra_envs into new_extra_envs with room for new envs */
-    for(i=0; i < self->num_extra_envs; i++) {
-        if((new_extra_envs[i] = strdup(self->extra_envs[i])) == NULL) {
-            errlogSevPrintf(errlogMinor, "strdup error for copying %s to new_extra_envs[%zu] from addReccasterEnvVars\n", self->extra_envs[i], i);
-            ret = 1;
-            break;
-        }
-    }
     int found_dup;
     /* sanitize input - check for dups and empty args */
-    if(!ret) {
-        for(i=0; i < argc; i++) {
-            if(argv[i] == NULL) {
-                errlogSevPrintf(errlogMinor, "Arg is NULL for addReccasterEnvVars\n");
-                continue;
-            }
-            else if(argv[i][0] == '\0') {
-                errlogSevPrintf(errlogMinor, "Arg is empty for addReccasterEnvVars\n");
-                continue;
-            }
-            found_dup = 0;
-            /* check if dup in self->default_envs */
-            for(j = 0; default_envs[j]; j++) {
-                if(strcmp(argv[i], default_envs[j]) == 0) {
-                    found_dup = 1;
-                    errlogSevPrintf(errlogMinor, "Env var %s is already in env list sent by reccaster by default\n", argv[i]);
-                    break;
-                }
-            }
-            if(found_dup) {
-                continue;
-            }
-            /* check if dup in self->extra_envs */
-            for(j = 0; j < num_new_extra_envs; j++) {
-                if(new_extra_envs[j] == NULL) {
-                    continue;
-                }
-                if(strcmp(argv[i], new_extra_envs[j]) == 0) {
-                    found_dup = 1;
-                    errlogSevPrintf(errlogMinor, "Env var %s is already in extra_envs list\n", argv[i]);
-                    break;
-                }
-            }
-            if(found_dup) {
-                continue;
-            }
-            if((new_extra_envs[num_new_extra_envs] = strdup(argv[i])) == NULL) {
-                errlogSevPrintf(errlogMinor, "strdup error for copying %s to new_extra_envs[%d] from addReccasterEnvVars\n", argv[i], num_new_extra_envs);
-                ret = 1;
+    for(i=0; i < argc; i++) {
+        if(argv[i][0] == '\0') {
+            errlogSevPrintf(errlogMinor, "Arg is empty for addReccasterEnvVars\n");
+            continue;
+        }
+        found_dup = 0;
+        /* check if dup in self->default_envs */
+        for(j = 0; default_envs[j]; j++) {
+            if(strcmp(argv[i], default_envs[j]) == 0) {
+                found_dup = 1;
                 break;
             }
-            /* this is a valid arg and we have added the new env var to our array, increment new_extra_envs count */
-            num_new_extra_envs++;
         }
+        if(found_dup) {
+            errlogSevPrintf(errlogMinor, "Env var %s is already in env list sent by reccaster by default\n", argv[i]);
+            continue;
+        }
+        /* check if dup in self->extra_envs */
+        ELLNODE *cur = ellFirst(&self->extra_envs);
+        while (cur != NULL) {
+            string_list_t *temp = (string_list_t *)cur;
+            if (strcmp(argv[i], temp->item_str) == 0) {
+                found_dup = 1;
+                break;
+            }
+            cur = ellNext(cur);
+        }
+        if(found_dup) {
+            errlogSevPrintf(errlogMinor, "Env var %s is already in extra_envs list\n", argv[i]);
+            continue;
+        }
+        string_list_t *new_list = malloc(sizeof(string_list_t));
+        if (new_list == NULL) {
+            errlogSevPrintf(errlogMajor, "Error in addReccasterEnvVars - malloc error for creating linked list node");
+            break;
+        }
+        new_list->item_str = strdup(argv[i]);
+        if (new_list->item_str == NULL) {
+            errlogSevPrintf(errlogMajor, "Error in addReccasterEnvVars - strdup error for copying %s to new->item_str from addReccasterEnvVars\n", argv[i]);
+            free(new_list);  /* frees if strdup fails */
+            break;
+        }
+        ellAdd(&self->extra_envs, &new_list->node);
     }
-    /* if we have no allocation issues and have at least one new env var that is valid, add to self->extra_envs */
-    if(!ret && num_new_extra_envs > self->num_extra_envs) {
-        /* from this point, nothing can fail */
-        char ** tmp;
-        tmp = self->extra_envs; /* swap pointers so we can clean up new_extra_envs on success/failure */
-        self->extra_envs = new_extra_envs;
-        new_extra_envs = tmp;
-
-        new_extra_envs_size = self->num_extra_envs; /* with swap of pointers also swap size */
-        self->num_extra_envs = num_new_extra_envs;
-    }
-    /* cleanup new_extra_envs[] on success or failure */
-    for(i = 0; i < new_extra_envs_size; i++) {
-        free(new_extra_envs[i]);
-    }
-    free(new_extra_envs);
     epicsMutexUnlock(self->lock);
-
-    if(ret) {
-        errlogSevPrintf(errlogMajor, "Error in addReccasterEnvVars - reccaster might not send the extra env vars specified\n");
-    }
 }
 
 static const iocshArg addReccasterEnvVarsArg0 = { "environmentVar", iocshArgArgv };

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -35,7 +35,6 @@ const char* default_envs[] =
     "PWD",
     "EPICS_HOST_ARCH",
     "IOCNAME",
-    "HOSTNAME",
 
     /* iocStats */
     "ENGINEER",
@@ -43,10 +42,10 @@ const char* default_envs[] =
 
     NULL
 };
+const size_t default_envs_count = NELEMENTS(default_envs) - 1;  /* exclude NULL */
 
 static int pushEnv(caster_t *caster)
 {
-    size_t i;
     ELLNODE *cur;
     int ret = 0;
 
@@ -64,16 +63,8 @@ static int pushEnv(caster_t *caster)
     if(ret)
         ERRRET(ret, caster, "Failed to send epics version");
 
-    for(i=0; !ret && default_envs[i]; i++) {
-        const char *val = getenv(default_envs[i]);
-        if(val && val[0]!='\0')
-            ret = casterSendInfo(caster, 0, default_envs[i], val);
-        if(ret)
-            casterMsg(caster, "Error sending env %s", default_envs[i]);
-    }
-
     epicsMutexMustLock(caster->lock);
-    for(cur = ellFirst(&caster->extra_envs); !ret && cur; cur = ellNext(cur)) {
+    for(cur = ellFirst(&caster->envs); !ret && cur; cur = ellNext(cur)) {
         const string_list_t *penvvar = CONTAINER(cur, string_list_t, node);
         const char *val = getenv(penvvar->item_str);
         if (val && val[0] != '\0')

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -47,6 +47,7 @@ const char* default_envs[] =
 static int pushEnv(caster_t *caster)
 {
     size_t i;
+    ELLNODE *cur;
     int ret = 0;
 
     if(!getenv("HOSTNAME")) {
@@ -72,15 +73,13 @@ static int pushEnv(caster_t *caster)
     }
 
     epicsMutexMustLock(caster->lock);
-    ELLNODE *env = ellFirst(&caster->extra_envs);
-    while (!ret && env != NULL) {
-        string_list_t *temp = (string_list_t *)env;
-        const char *val = getenv(temp->item_str);
+    for(cur = ellFirst(&caster->extra_envs); !ret && cur; cur = ellNext(cur)) {
+        const string_list_t *penvvar = CONTAINER(cur, string_list_t, node);
+        const char *val = getenv(penvvar->item_str);
         if (val && val[0] != '\0')
-            ret = casterSendInfo(caster, 0, temp->item_str, val);
+            ret = casterSendInfo(caster, 0, penvvar->item_str, val);
         if (ret)
-            casterMsg(caster, "Error sending env %s", temp->item_str);
-        env = ellNext(env);
+            casterMsg(caster, "Error sending env %s", penvvar->item_str);
     }
     epicsMutexUnlock(caster->lock);
 

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -72,12 +72,13 @@ static int pushEnv(caster_t *caster)
     }
 
     epicsMutexMustLock(caster->lock);
-    for (i = 0; !ret && i < caster->num_extra_envs; i++) {
-        const char *val = getenv(caster->extra_envs[i]);
+    for (i = 0; !ret && i < caster->extra_envs.count; i++) {
+        string_list_t *envptr = (string_list_t *)ellNth(&caster->extra_envs, i);
+        const char *val = getenv(envptr->item_str);
         if (val && val[0] != '\0')
-            ret = casterSendInfo(caster, 0, caster->extra_envs[i], val);
+            ret = casterSendInfo(caster, 0, envptr->item_str, val);
         if (ret)
-            casterMsg(caster, "Error sending env %s", caster->extra_envs[i]);
+            casterMsg(caster, "Error sending env %s", envptr->item_str);
     }
     epicsMutexUnlock(caster->lock);
 

--- a/client/castApp/src/dbcb.c
+++ b/client/castApp/src/dbcb.c
@@ -72,13 +72,15 @@ static int pushEnv(caster_t *caster)
     }
 
     epicsMutexMustLock(caster->lock);
-    for (i = 0; !ret && i < caster->extra_envs.count; i++) {
-        string_list_t *envptr = (string_list_t *)ellNth(&caster->extra_envs, i);
-        const char *val = getenv(envptr->item_str);
+    ELLNODE *env = ellFirst(&caster->extra_envs);
+    while (!ret && env != NULL) {
+        string_list_t *temp = (string_list_t *)env;
+        const char *val = getenv(temp->item_str);
         if (val && val[0] != '\0')
-            ret = casterSendInfo(caster, 0, envptr->item_str, val);
+            ret = casterSendInfo(caster, 0, temp->item_str, val);
         if (ret)
-            casterMsg(caster, "Error sending env %s", envptr->item_str);
+            casterMsg(caster, "Error sending env %s", temp->item_str);
+        env = ellNext(env);
     }
     epicsMutexUnlock(caster->lock);
 

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -31,11 +31,7 @@ static void testAddEnvVarsX(void)
         "DEVICE",
         "FAMILY"
     };
-    size_t defaultEnvCount = 0;
-    while (default_envs[defaultEnvCount]) {
-        defaultEnvCount++;
-    }
-    int expectedNumExtraEnvs = defaultEnvCount;
+    int expectedNumExtraEnvs = default_envs_count;
 
     testDiag("Testing addReccasterEnvVars with one good env");
     argvlist[1] = "SECTOR";
@@ -49,11 +45,11 @@ static void testAddEnvVarsX(void)
     cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        if (i < defaultEnvCount) {
+        if (i < default_envs_count) {
             testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
         }
         else {
-            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - default_envs_count]) == 0);
         }
         i++;
         cur = ellNext(cur);
@@ -71,11 +67,11 @@ static void testAddEnvVarsX(void)
     cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        if (i < defaultEnvCount) {
+        if (i < default_envs_count) {
             testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
         }
         else {
-            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - default_envs_count]) == 0);
         }
         i++;
         cur = ellNext(cur);
@@ -91,11 +87,11 @@ static void testAddEnvVarsX(void)
     cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        if (i < defaultEnvCount) {
+        if (i < default_envs_count) {
             testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
         }
         else {
-            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - default_envs_count]) == 0);
         }
         i++;
         cur = ellNext(cur);
@@ -113,11 +109,11 @@ static void testAddEnvVarsX(void)
     cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        if (i < defaultEnvCount) {
+        if (i < default_envs_count) {
             testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
         }
         else {
-            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - default_envs_count]) == 0);
         }
         i++;
         cur = ellNext(cur);
@@ -135,11 +131,11 @@ static void testAddEnvVarsX(void)
     cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        if (i < defaultEnvCount) {
+        if (i < default_envs_count) {
             testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
         }
         else {
-            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - default_envs_count]) == 0);
         }
         i++;
         cur = ellNext(cur);
@@ -159,11 +155,11 @@ static void testAddEnvVarsX(void)
     cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        if (i < defaultEnvCount) {
+        if (i < default_envs_count) {
             testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
         }
         else {
-            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - default_envs_count]) == 0);
         }
         i++;
         cur = ellNext(cur);
@@ -179,27 +175,22 @@ static void testAddEnvVarsBadInput(void)
     casterInit(&caster);
     caster.onmsg = &testLog;
 
-    size_t defaultEnvCount = 0;
-    while (default_envs[defaultEnvCount]) {
-        defaultEnvCount++;
-    }
-
     int argc;
     char *argvlist[3];
     argvlist[0] = "addReccasterEnvVars";
 
     testDiag("Testing addReccasterEnvVars with no arguments");
     argc = 1;
-    testOk1(caster.envs.count==defaultEnvCount);
+    testOk1(caster.envs.count==default_envs_count);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.envs.count==defaultEnvCount);
+    testOk1(caster.envs.count==default_envs_count);
 
     testDiag("Testing addReccasterEnvVars with empty string argument");
     argvlist[1] = "";
     argc = 2;
-    testOk1(caster.envs.count==defaultEnvCount);
+    testOk1(caster.envs.count==default_envs_count);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.envs.count==defaultEnvCount);
+    testOk1(caster.envs.count==default_envs_count);
 
     epicsEventSignal(caster.shutdownEvent);
     casterShutdown(&caster);

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -14,7 +14,7 @@ static void testLog(void* arg, struct _caster_t* self)
 
 static void testAddEnvVarsX(void)
 {
-    int i;
+    int i = 0;
     caster_t caster;
     casterInit(&caster);
     caster.onmsg = &testLog;
@@ -29,7 +29,6 @@ static void testAddEnvVarsX(void)
         "BUILDING",
         "CONTACT",
         "DEVICE",
-        "Field",
         "FAMILY"
     };
     int expectedNumExtraEnvs = 0;
@@ -37,71 +36,84 @@ static void testAddEnvVarsX(void)
     testDiag("Testing addReccasterEnvVars with one good env");
     argvlist[1] = "SECTOR";
     argc = 2;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
+    i = 0;
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs++;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    ELLNODE *cur;
+    cur = ellFirst(&caster.extra_envs);
+    while (cur != NULL) {
+        string_list_t *temp = (string_list_t *)cur;
+        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        i++;
+        cur = ellNext(cur);
     }
 
     testDiag("Testing addReccasterEnvVars with two more good envs");
     argvlist[1] = "BUILDING";
     argvlist[2] = "CONTACT";
     argc = 3;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
+    i = 0;
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs += 2;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.extra_envs);
+    while (cur != NULL) {
+        string_list_t *temp = (string_list_t *)cur;
+        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        i++;
+        cur = ellNext(cur);
     }
 
     testDiag("Testing addReccasterEnvVars with duplicate env");
     argvlist[1] = "SECTOR";
     argc = 2;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
+    i = 0;
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.extra_envs);
+    while (cur != NULL) {
+        string_list_t *temp = (string_list_t *)cur;
+        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        i++;
+        cur = ellNext(cur);
     }
 
     testDiag("Testing addReccasterEnvVars with one dup and one good env");
     argvlist[1] = "CONTACT";
     argvlist[2] = "DEVICE";
     argc = 3;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
+    i = 0;
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs++;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
-    }
-
-    testDiag("Testing addReccasterEnvVars with NULL argument and then a good env");
-    argvlist[1] = NULL;
-    argvlist[2] = "Field";
-    argc = 3;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    addReccasterEnvVars(&caster, argc, argvlist);
-    expectedNumExtraEnvs++;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.extra_envs);
+    while (cur != NULL) {
+        string_list_t *temp = (string_list_t *)cur;
+        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        i++;
+        cur = ellNext(cur);
     }
 
     testDiag("Testing addReccasterEnvVars with a good env and a dup of that env");
-    argvlist[1] = NULL;
+    argvlist[1] = "FAMILY";
     argvlist[2] = "FAMILY";
-    argvlist[3] = "FAMILY";
-    argc = 4;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
+    argc = 3;
+    i = 0;
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs++;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.extra_envs);
+    while (cur != NULL) {
+        string_list_t *temp = (string_list_t *)cur;
+        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        i++;
+        cur = ellNext(cur);
     }
 
     testDiag("Testing addReccasterEnvVars with a env vars from default list");
@@ -111,11 +123,16 @@ static void testAddEnvVarsX(void)
     argvlist[4] = "RSRV_SERVER_PORT";
     argvlist[5] = "ENGINEER";
     argc = 6;
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
+    i = 0;
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.num_extra_envs==expectedNumExtraEnvs);
-    for(i=0; i < expectedNumExtraEnvs; i++) {
-        testOk1(strcmp(caster.extra_envs[i], expectedExtraEnvs[i]) == 0);
+    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.extra_envs);
+    while (cur != NULL) {
+        string_list_t *temp = (string_list_t *)cur;
+        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        i++;
+        cur = ellNext(cur);
     }
 
     epicsEventSignal(caster.shutdownEvent);
@@ -134,23 +151,16 @@ static void testAddEnvVarsBadInput(void)
 
     testDiag("Testing addReccasterEnvVars with no arguments");
     argc = 1;
-    testOk1(caster.num_extra_envs==0);
+    testOk1(caster.extra_envs.count==0);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.num_extra_envs==0);
+    testOk1(caster.extra_envs.count==0);
 
     testDiag("Testing addReccasterEnvVars with empty string argument");
     argvlist[1] = "";
     argc = 2;
-    testOk1(caster.num_extra_envs==0);
+    testOk1(caster.extra_envs.count==0);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.num_extra_envs==0);
-
-    testDiag("Testing addReccasterEnvVars with NULL argument");
-    argvlist[1] = NULL;
-    argc = 2;
-    testOk1(caster.num_extra_envs==0);
-    addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.num_extra_envs==0);
+    testOk1(caster.extra_envs.count==0);
 
     epicsEventSignal(caster.shutdownEvent);
     casterShutdown(&caster);
@@ -158,7 +168,7 @@ static void testAddEnvVarsBadInput(void)
 
 MAIN(testAddEnvVars)
 {
-    testPlan(48);
+    testPlan(37);
     osiSockAttach();
     testAddEnvVarsX();
     testAddEnvVarsBadInput();

--- a/client/castApp/src/testAddEnvVars.c
+++ b/client/castApp/src/testAddEnvVars.c
@@ -31,21 +31,30 @@ static void testAddEnvVarsX(void)
         "DEVICE",
         "FAMILY"
     };
-    int expectedNumExtraEnvs = 0;
+    size_t defaultEnvCount = 0;
+    while (default_envs[defaultEnvCount]) {
+        defaultEnvCount++;
+    }
+    int expectedNumExtraEnvs = defaultEnvCount;
 
     testDiag("Testing addReccasterEnvVars with one good env");
     argvlist[1] = "SECTOR";
     argc = 2;
     i = 0;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs++;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     ELLNODE *cur;
-    cur = ellFirst(&caster.extra_envs);
+    cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        if (i < defaultEnvCount) {
+            testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
+        }
+        else {
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+        }
         i++;
         cur = ellNext(cur);
     }
@@ -55,14 +64,19 @@ static void testAddEnvVarsX(void)
     argvlist[2] = "CONTACT";
     argc = 3;
     i = 0;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs += 2;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
-    cur = ellFirst(&caster.extra_envs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        if (i < defaultEnvCount) {
+            testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
+        }
+        else {
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+        }
         i++;
         cur = ellNext(cur);
     }
@@ -71,13 +85,18 @@ static void testAddEnvVarsX(void)
     argvlist[1] = "SECTOR";
     argc = 2;
     i = 0;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
-    cur = ellFirst(&caster.extra_envs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        if (i < defaultEnvCount) {
+            testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
+        }
+        else {
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+        }
         i++;
         cur = ellNext(cur);
     }
@@ -87,14 +106,19 @@ static void testAddEnvVarsX(void)
     argvlist[2] = "DEVICE";
     argc = 3;
     i = 0;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs++;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
-    cur = ellFirst(&caster.extra_envs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        if (i < defaultEnvCount) {
+            testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
+        }
+        else {
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+        }
         i++;
         cur = ellNext(cur);
     }
@@ -104,14 +128,19 @@ static void testAddEnvVarsX(void)
     argvlist[2] = "FAMILY";
     argc = 3;
     i = 0;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
     expectedNumExtraEnvs++;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
-    cur = ellFirst(&caster.extra_envs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
+    cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        if (i < defaultEnvCount) {
+            testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
+        }
+        else {
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+        }
         i++;
         cur = ellNext(cur);
     }
@@ -124,13 +153,18 @@ static void testAddEnvVarsX(void)
     argvlist[5] = "ENGINEER";
     argc = 6;
     i = 0;
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.extra_envs.count==expectedNumExtraEnvs);
-    cur = ellFirst(&caster.extra_envs);
+    testOk1(caster.envs.count==expectedNumExtraEnvs); /* these are all defaults so the count should not change */
+    cur = ellFirst(&caster.envs);
     while (cur != NULL) {
         string_list_t *temp = (string_list_t *)cur;
-        testOk1(strcmp(temp->item_str, expectedExtraEnvs[i]) == 0);
+        if (i < defaultEnvCount) {
+            testOk1(strcmp(temp->item_str, default_envs[i]) == 0);
+        }
+        else {
+            testOk1(strcmp(temp->item_str, expectedExtraEnvs[i - defaultEnvCount]) == 0);
+        }
         i++;
         cur = ellNext(cur);
     }
@@ -145,22 +179,27 @@ static void testAddEnvVarsBadInput(void)
     casterInit(&caster);
     caster.onmsg = &testLog;
 
+    size_t defaultEnvCount = 0;
+    while (default_envs[defaultEnvCount]) {
+        defaultEnvCount++;
+    }
+
     int argc;
-    char *argvlist[2];
+    char *argvlist[3];
     argvlist[0] = "addReccasterEnvVars";
 
     testDiag("Testing addReccasterEnvVars with no arguments");
     argc = 1;
-    testOk1(caster.extra_envs.count==0);
+    testOk1(caster.envs.count==defaultEnvCount);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.extra_envs.count==0);
+    testOk1(caster.envs.count==defaultEnvCount);
 
     testDiag("Testing addReccasterEnvVars with empty string argument");
     argvlist[1] = "";
     argc = 2;
-    testOk1(caster.extra_envs.count==0);
+    testOk1(caster.envs.count==defaultEnvCount);
     addReccasterEnvVars(&caster, argc, argvlist);
-    testOk1(caster.extra_envs.count==0);
+    testOk1(caster.envs.count==defaultEnvCount);
 
     epicsEventSignal(caster.shutdownEvent);
     casterShutdown(&caster);
@@ -168,7 +207,7 @@ static void testAddEnvVarsBadInput(void)
 
 MAIN(testAddEnvVars)
 {
-    testPlan(37);
+    testPlan(37 + default_envs_count * 6);
     osiSockAttach();
     testAddEnvVarsX();
     testAddEnvVarsBadInput();

--- a/client/castApp/src/testAddExcludePattern.c
+++ b/client/castApp/src/testAddExcludePattern.c
@@ -142,7 +142,7 @@ static void testAddExcludePatternBadInput()
     caster.onmsg = &testLog;
 
     int argc;
-    char *argvlist[3];
+    char *argvlist[2];
     argvlist[0] = "addReccasterExcludePattern";
 
     testDiag("Testing addReccasterExcludePattern with no arguments");

--- a/client/castApp/src/testAddExcludePattern.c
+++ b/client/castApp/src/testAddExcludePattern.c
@@ -142,7 +142,7 @@ static void testAddExcludePatternBadInput()
     caster.onmsg = &testLog;
 
     int argc;
-    char *argvlist[2];
+    char *argvlist[3];
     argvlist[0] = "addReccasterExcludePattern";
 
     testDiag("Testing addReccasterExcludePattern with no arguments");


### PR DESCRIPTION
This PR is in place of https://github.com/ChannelFinder/recsync/pull/117 so the git merging/commit history isn't messed up. I branched off the latest in master, cherry-picked @madelinespark 's two commits, and worked off that.

- Updated the memory allocation and looping to match this suggestion https://github.com/ChannelFinder/recsync/pull/117#discussion_r2347028501
- Created function to handle both `addReccasterEnvVars` and `addReccasterExcludePattern` logic
- Added `IOCSHFUNCDEF_HAS_USAGE` message for `addReccasterExcludePattern`

Madeline's commits already converted `addReccasterEnvVars` to a linked list implementation and updated all the unit tests.