### PR TITLE
Refactor cfstore to dataclasses

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -66,7 +66,7 @@
 [cf]
 # cf-store application
 # a space-separated list of infotags to set as CF Properties
-#infotags = archive foo bar blah
+#infotags = archive, foo, bar, blah
 
 # Uncomment line below to turn off the feature to add CA/PVA port info for name server to channelfinder
 #iocConnectionInfo = False

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -12,6 +12,7 @@ version="1.5"
 readme = "README.md"
 requires-python = ">=3.6"
 dependencies = [
+    "dataclasses; python_version < '3.7'",
     "requests",
     "twisted",
     "channelfinder @ https://github.com/ChannelFinder/pyCFClient/archive/refs/tags/v3.0.0.zip"

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -222,14 +222,14 @@ class CFChannel:
             "properties": [p.as_dict() for p in self.properties],
         }
 
-    @staticmethod
-    def from_channelfinder_dict(channel_dict: Dict[str, Any]) -> "CFChannel":
+    @classmethod
+    def from_channelfinder_dict(cls, channel_dict: Dict[str, Any]) -> "CFChannel":
         """Create CFChannel from Channelfinder json output.
 
         Args:
             channel_dict: Dictionary representing a channel from Channelfinder.
         """
-        return CFChannel(
+        return cls(
             name=channel_dict.get("name", ""),
             owner=channel_dict.get("owner", ""),
             properties=[CFProperty.from_channelfinder_dict(p) for p in channel_dict.get("properties", [])],

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -1042,6 +1042,14 @@ def create_new_channel(
                 _log.debug("Add new alias: %s from %s", alias, channel_name)
 
 
+class IOCMissingInfoError(Exception):
+    """Raised when an IOC is missing required information."""
+
+    def __init__(self, ioc_info: IocInfo):
+        super().__init__(f"Missing hostName {ioc_info.hostname} or iocName {ioc_info.ioc_name}")
+        self.ioc_info = ioc_info
+
+
 def _update_channelfinder(
     processor: CFProcessor, record_info_by_name: Dict[str, RecordInfo], records_to_delete, ioc_info: IocInfo
 ) -> None:
@@ -1070,7 +1078,7 @@ def _update_channelfinder(
         _log.warning("IOC Env Info %s not found in ioc list: %s", ioc_info, iocs)
 
     if ioc_info.hostname is None or ioc_info.ioc_name is None:
-        raise Exception(f"Missing hostName {ioc_info.hostname} or iocName {ioc_info.ioc_name}")
+        raise IOCMissingInfoError(ioc_info)
 
     if processor.cancelled:
         raise defer.CancelledError(f"Processor cancelled in _update_channelfinder for {ioc_info}")

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -343,9 +343,9 @@ class CFProcessor(service.Service):
         """Stop the CFProcessor service."""
         _log.info("CF_STOP")
         service.Service.stopService(self)
-        return self.lock.run(self._stopServiceWithLock)
+        return self.lock.run(self._stop_service_with_lock)
 
-    def _stopServiceWithLock(self):
+    def _stop_service_with_lock(self):
         """Stop the CFProcessor service with lock held.
 
         If clean_on_stop is enabled, mark all channels as inactive.

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -560,7 +560,7 @@ class CFProcessor(service.Service):
 
         record_info_by_name = self.record_info_by_name(record_infos, ioc_info)
         self.update_ioc_infos(transaction, ioc_info, records_to_delete, record_info_by_name)
-        poll(__updateCF__, self, record_info_by_name, records_to_delete, ioc_info)
+        poll(_update_channelfinder, self, record_info_by_name, records_to_delete, ioc_info)
 
     def remove_channel(self, recordName: str, iocid: str) -> None:
         """Remove channel from self.iocs and self.channel_ioc_ids.
@@ -1039,7 +1039,7 @@ def create_new_channel(
                 _log.debug("Add new alias: %s from %s", alias, channel_name)
 
 
-def __updateCF__(
+def _update_channelfinder(
     processor: CFProcessor, record_info_by_name: Dict[str, RecordInfo], records_to_delete, ioc_info: IocInfo
 ) -> None:
     """Update Channelfinder with the provided IOC and Record information.
@@ -1070,7 +1070,7 @@ def __updateCF__(
         raise Exception(f"Missing hostName {ioc_info.hostname} or iocName {ioc_info.ioc_name}")
 
     if processor.cancelled:
-        raise defer.CancelledError(f"Processor cancelled in __updateCF__ for {ioc_info}")
+        raise defer.CancelledError(f"Processor cancelled in _update_channelfinder for {ioc_info}")
 
     channels: List[CFChannel] = []
     # A list of channels in channelfinder with the associated hostName and iocName
@@ -1140,7 +1140,7 @@ def __updateCF__(
         if old_channels and len(old_channels) != 0:
             cf_set_chunked(client, channels, cf_config.cf_query_limit)
     if processor.cancelled:
-        raise defer.CancelledError(f"Processor cancelled in __updateCF__ for {ioc_info}")
+        raise defer.CancelledError(f"Processor cancelled in _update_channelfinder for {ioc_info}")
 
 
 def cf_set_chunked(client: ChannelFinderClient, channels: List[CFChannel], chunk_size=10000) -> None:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -85,7 +85,7 @@ class CFProperty:
 
     def as_dict(self) -> Dict[str, str]:
         """Convert to dictionary for Channelfinder API."""
-        return {"name": self.name, "owner": self.owner, "value": str(self.value)}
+        return {"name": self.name, "owner": self.owner, "value": self.value or ""}
 
     @staticmethod
     def from_channelfinder_dict(prop_dict: Dict[str, str]) -> "CFProperty":

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -880,7 +880,7 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
     existingChannels = get_existing_channels(new_channels, client, cf_config, processor)
 
     for channel_name in new_channels:
-        newProps = create_properties(
+        newProps = create_ioc_properties(
             ioc_info.owner,
             ioc_info.time,
             recceiverid,
@@ -931,7 +931,9 @@ def cf_set_chunked(client, channels: List[CFChannel], chunk_size=10000):
         client.set(channels=chunk)
 
 
-def create_properties(owner: str, iocTime: str, recceiverid: str, hostName: str, iocName: str, iocIP: str, iocid: str):
+def create_ioc_properties(
+    owner: str, iocTime: str, recceiverid: str, hostName: str, iocName: str, iocIP: str, iocid: str
+):
     return [
         CFProperty(CFPropertyName.hostName.name, owner, hostName),
         CFProperty(CFPropertyName.iocName.name, owner, iocName),
@@ -948,7 +950,7 @@ def create_default_properties(
 ):
     channel_name = cf_channel.name
     last_ioc_info = iocs[channels_iocs[channel_name][-1]]
-    return create_properties(
+    return create_ioc_properties(
         ioc_info.owner,
         ioc_info.time,
         recceiverid,

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -414,9 +414,7 @@ class CFProcessor(service.Service):
         t.addCallbacks(chainResult, chainError)
         return d
 
-    def transaction_to_recordInfosById(
-        self, ioc_info: IocInfo, transaction: CommitTransaction
-    ) -> Dict[str, RecordInfo]:
+    def transaction_to_record_infos(self, ioc_info: IocInfo, transaction: CommitTransaction) -> Dict[str, RecordInfo]:
         """Convert a CommitTransaction and IocInfo to a dictionary of RecordInfo objects.
 
         Combines record additions, info tags, aliases, and environment variables.
@@ -557,7 +555,7 @@ class CFProcessor(service.Service):
             channelcount=0,
         )
 
-        recordInfoById = self.transaction_to_recordInfosById(ioc_info, transaction)
+        recordInfoById = self.transaction_to_record_infos(ioc_info, transaction)
 
         records_to_delete = list(transaction.records_to_delete)
         _log.debug("Delete records: %s", records_to_delete)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -560,7 +560,7 @@ class CFProcessor(service.Service):
 
         record_info_by_name = self.record_info_by_name(record_infos, ioc_info)
         self.update_ioc_infos(transaction, ioc_info, records_to_delete, record_info_by_name)
-        poll(_updateCF, self, record_info_by_name, records_to_delete, ioc_info)
+        poll(__updateCF__, self, record_info_by_name, records_to_delete, ioc_info)
 
     def remove_channel(self, recordName: str, iocid: str) -> None:
         """Remove channel from self.iocs and self.channel_ioc_ids.
@@ -866,7 +866,9 @@ def get_existing_channels(
         for found_channel in client.findByArgs(prepareFindArgs(cf_config, [("~name", each_search_string)])):
             existing_channels[found_channel["name"]] = CFChannel.from_channelfinder_dict(found_channel)
         if processor.cancelled:
-            raise defer.CancelledError()
+            raise defer.CancelledError(
+                f"CF Processor is cancelled, while searching for existing channels: {each_search_string}"
+            )
     return existing_channels
 
 
@@ -1037,7 +1039,7 @@ def create_new_channel(
                 _log.debug("Add new alias: %s from %s", alias, channel_name)
 
 
-def _updateCF(
+def __updateCF__(
     processor: CFProcessor, record_info_by_name: Dict[str, RecordInfo], records_to_delete, ioc_info: IocInfo
 ) -> None:
     """Update Channelfinder with the provided IOC and Record information.

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -393,7 +393,7 @@ class CFProcessor(service.Service):
             Note this is not foolproof as the thread may still be running.
             """
             if not err.check(defer.CancelledError):
-                _log.error("CF_COMMIT FAILURE: {s}".format(s=err))
+                _log.error("CF_COMMIT FAILURE: %s", err)
             if self.cancelled:
                 if not err.check(defer.CancelledError):
                     raise defer.CancelledError()
@@ -599,7 +599,7 @@ class CFProcessor(service.Service):
                     _log.info("CF Clean Completed")
                     return
             except RequestException as e:
-                _log.error("Clean service failed: {s}".format(s=e))
+                _log.error("Clean service failed: %s", e)
             retry_seconds = min(60, sleep)
             _log.info("Clean service retry in %s seconds", retry_seconds)
             time.sleep(retry_seconds)
@@ -1277,9 +1277,9 @@ def poll(
             success = True
             return success
         except RequestException as e:
-            _log.error("ChannelFinder update failed: {s}".format(s=e))
+            _log.error("ChannelFinder update failed: %s", e)
             retry_seconds = min(60, sleep)
-            _log.info("ChannelFinder update retry in {retry_seconds} seconds".format(retry_seconds=retry_seconds))
+            _log.info("ChannelFinder update retry in %s seconds", retry_seconds)
             time.sleep(retry_seconds)
             sleep *= 1.5
     _log.info("Polling %s complete", ioc_info)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -574,7 +574,7 @@ class CFProcessor(service.Service):
         if iocid in self.iocs:
             self.iocs[iocid].channelcount -= 1
         if self.iocs[iocid].channelcount == 0:
-            self.iocs.pop(iocid, None)
+            self.iocs.pop(iocid)
         elif self.iocs[iocid].channelcount < 0:
             _log.error("Channel count negative: %s", iocid)
         if len(self.channel_ioc_ids[recordName]) <= 0:  # case: channel has no more iocs

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -380,21 +380,21 @@ class CFProcessor(service.Service):
 
         t = deferToThread(self._commit_with_thread, transaction)
 
-        def cancelCommit(d: defer.Deferred):
+        def cancel_commit(d: defer.Deferred):
             """Cancel the commit operation."""
             self.cancelled = True
             d.callback(None)
 
-        d: defer.Deferred = defer.Deferred(cancelCommit)
+        d: defer.Deferred = defer.Deferred(cancel_commit)
 
-        def waitForThread(_ignored):
+        def wait_for_thread(_ignored):
             """Wait for the commit thread to finish."""
             if self.cancelled:
                 return t
 
-        d.addCallback(waitForThread)
+        d.addCallback(wait_for_thread)
 
-        def chainError(err):
+        def chain_error(err):
             """Handle errors from the commit thread.
 
             Note this is not foolproof as the thread may still be running.
@@ -408,7 +408,7 @@ class CFProcessor(service.Service):
             else:
                 d.callback(None)
 
-        def chainResult(result):
+        def chain_result(result):
             """Handle successful completion of the commit thread.
 
             If the commit was cancelled, raise CancelledError.
@@ -418,7 +418,7 @@ class CFProcessor(service.Service):
             else:
                 d.callback(None)
 
-        t.addCallbacks(chainResult, chainError)
+        t.addCallbacks(chain_result, chain_error)
         return d
 
     def transaction_to_record_infos(self, ioc_info: IocInfo, transaction: CommitTransaction) -> Dict[str, RecordInfo]:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -27,6 +27,7 @@ _log = logging.getLogger(__name__)
 __all__ = ["CFProcessor"]
 
 RECCEIVERID_DEFAULT = socket.gethostname()
+DEFAULT_MAX_CHANNEL_NAME_QUERY_LENGTH = 600
 
 
 @dataclass

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -197,8 +197,8 @@ class IocInfo:
     ioc_IP: str
     owner: str
     time: str
-    channelcount: int
     port: int
+    channelcount: int = 0
 
     @property
     def ioc_id(self):
@@ -551,7 +551,6 @@ class CFProcessor(service.Service):
             ),
             time=self.current_time(self.cf_config.timezone),
             port=transaction.source_address.port,
-            channelcount=0,
         )
 
         record_infos = self.transaction_to_record_infos(ioc_info, transaction)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -10,27 +10,17 @@ from typing import Dict, List, Optional, Set
 
 from channelfinder import ChannelFinderClient
 from requests import ConnectionError, RequestException
-from zope.interface import implementer
-
 from twisted.application import service
 from twisted.internet import defer
 from twisted.internet.defer import DeferredLock
 from twisted.internet.threads import deferToThread
+from zope.interface import implementer
 
 from . import interfaces
+from .interfaces import CommitTransaction
 from .processors import ConfigAdapter
 
 _log = logging.getLogger(__name__)
-
-# ITRANSACTION FORMAT:
-#
-# source_address = source address
-# records_to_add = records ein added ( recname, rectype, {key:val})
-# records_to_delete = a set() of records which are being removed
-# client_infos = dictionary of client client_infos
-# record_infos_to_add = additional client_infos being added to existing records
-# "recid: {key:value}"
-#
 
 __all__ = ["CFProcessor"]
 
@@ -234,7 +224,7 @@ class CFProcessor(service.Service):
         t.addCallbacks(chainResult, chainError)
         return d
 
-    def _commitWithThread(self, transaction):
+    def _commitWithThread(self, transaction: CommitTransaction):
         if not self.running:
             raise defer.CancelledError(
                 "CF Processor is not running (transaction: {host}:{port})",

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -350,11 +350,9 @@ class CFProcessor(service.Service):
 
     def _commitWithThread(self, transaction: CommitTransaction):
         if not self.running:
-            raise defer.CancelledError(
-                "CF Processor is not running (transaction: {host}:{port})",
-                host=transaction.source_address.host,
-                port=transaction.source_address.port,
-            )
+            host = transaction.source_address.host
+            port = transaction.source_address.port
+            raise defer.CancelledError(f"CF Processor is not running (transaction: {host}:{port})")
 
         _log.info("CF_COMMIT: {transaction}".format(transaction=transaction))
         _log.debug("CF_COMMIT: transaction: {s}".format(s=repr(transaction)))

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -267,14 +267,14 @@ class CFProcessor(service.Service):
             raise RuntimeError("Failed to acquired CF Processor lock for service start")
 
         try:
-            self._startServiceWithLock()
+            self._start_service_with_lock()
         except:
             service.Service.stopService(self)
             raise
         finally:
             self.lock.release()
 
-    def _startServiceWithLock(self):
+    def _start_service_with_lock(self):
         """Start the CFProcessor service with lock held.
 
         Using the default python cf-client.  The url, username, and

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -986,20 +986,20 @@ def update_existing_channel_diff_iocid(
     # in case, alias exists, update their properties too
     if cf_config.alias_enabled:
         if channel_name in record_info_by_name:
-            alProps = [CFProperty.alias(ioc_info.owner, channel_name)]
+            alias_properties = [CFProperty.alias(ioc_info.owner, channel_name)]
             for p in newProps:
-                alProps.append(p)
+                alias_properties.append(p)
             for alias_name in record_info_by_name[channel_name].aliases:
                 if alias_name in existing_channels:
                     ach = existing_channels[alias_name]
                     ach.properties = __merge_property_lists(
-                        alProps,
+                        alias_properties,
                         ach,
                         processor.managed_properties,
                     )
                     channels.append(ach)
                 else:
-                    channels.append(CFChannel(alias_name, ioc_info.owner, alProps))
+                    channels.append(CFChannel(alias_name, ioc_info.owner, alias_properties))
                 _log.debug("Add existing alias %s of %s with different IOC from %s", alias_name, channel_name, iocid)
 
 
@@ -1029,11 +1029,11 @@ def create_new_channel(
     _log.debug("Add new channel: %s", channel_name)
     if cf_config.alias_enabled:
         if channel_name in record_info_by_name:
-            alProps = [CFProperty.alias(ioc_info.owner, channel_name)]
+            alias_properties = [CFProperty.alias(ioc_info.owner, channel_name)]
             for p in newProps:
-                alProps.append(p)
+                alias_properties.append(p)
             for alias in record_info_by_name[channel_name].aliases:
-                channels.append(CFChannel(alias, ioc_info.owner, alProps))
+                channels.append(CFChannel(alias, ioc_info.owner, alias_properties))
                 _log.debug("Add new alias: %s from %s", alias, channel_name)
 
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -682,12 +682,6 @@ def handle_channel_is_old(
         cf_channel,
         processor.managed_properties,
     )
-    if cf_config.record_type_enabled:
-        cf_channel.properties = __merge_property_lists(
-            cf_channel.properties.append(CFProperty.recordType(ioc_info.owner, iocs[last_ioc_id]["recordType"])),
-            cf_channel,
-            processor.managed_properties,
-        )
     channels.append(cf_channel)
     _log.debug("Add existing channel %s to previous IOC %s", cf_channel, last_ioc_id)
     # In case alias exist, also delete them
@@ -710,17 +704,6 @@ def handle_channel_is_old(
                         alias_channel,
                         processor.managed_properties,
                     )
-                    if cf_config.record_type_enabled:
-                        cf_channel.properties = __merge_property_lists(
-                            cf_channel.properties.append(
-                                CFProperty.recordType(
-                                    ioc_info.owner,
-                                    iocs[last_alias_ioc_id]["recordType"],
-                                )
-                            ),
-                            cf_channel,
-                            processor.managed_properties,
-                        )
                     channels.append(alias_channel)
                     _log.debug("Add existing alias %s to previous IOC: %s", alias_channel, last_alias_ioc_id)
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -423,34 +423,34 @@ class CFProcessor(service.Service):
             ioc_info: Information from the IOC
             transaction: transaction from reccaster
         """
-        recordInfo: Dict[str, RecordInfo] = {}
+        record_infos: Dict[str, RecordInfo] = {}
         for record_id, (record_name, record_type) in transaction.records_to_add.items():
-            recordInfo[record_id] = RecordInfo(pv_name=record_name, record_type=None, info_properties=[], aliases=[])
+            record_infos[record_id] = RecordInfo(pv_name=record_name, record_type=None, info_properties=[], aliases=[])
             if self.cf_config.record_type_enabled:
-                recordInfo[record_id].record_type = record_type
+                record_infos[record_id].record_type = record_type
 
         for record_id, (record_infos_to_add) in transaction.record_infos_to_add.items():
             # find intersection of these sets
-            if record_id not in recordInfo:
+            if record_id not in record_infos:
                 _log.warning("IOC: %s: PV not found for recinfo with RID: {record_id}", ioc_info, record_id)
                 continue
             recinfo_wl = [p for p in self.record_property_names_list if p in record_infos_to_add.keys()]
             if recinfo_wl:
                 for infotag in recinfo_wl:
-                    recordInfo[record_id].info_properties.append(
+                    record_infos[record_id].info_properties.append(
                         CFProperty(infotag, ioc_info.owner, record_infos_to_add[infotag])
                     )
 
         for record_id, record_aliases in transaction.aliases.items():
-            if record_id not in recordInfo:
+            if record_id not in record_infos:
                 _log.warning("IOC: %s: PV not found for alias with RID: %s", ioc_info, record_id)
                 continue
-            recordInfo[record_id].aliases = record_aliases
+            record_infos[record_id].aliases = record_aliases
 
-        for record_id in recordInfo:
+        for record_id in record_infos:
             for epics_env_var_name, cf_prop_name in self.env_vars.items():
                 if transaction.client_infos.get(epics_env_var_name) is not None:
-                    recordInfo[record_id].info_properties.append(
+                    record_infos[record_id].info_properties.append(
                         CFProperty(cf_prop_name, ioc_info.owner, transaction.client_infos.get(epics_env_var_name))
                     )
                 else:
@@ -459,7 +459,7 @@ class CFProcessor(service.Service):
                         epics_env_var_name,
                         ioc_info,
                     )
-        return recordInfo
+        return record_infos
 
     def record_info_by_name(
         self, recordInfosByRecordID: Dict[str, RecordInfo], ioc_info: IocInfo

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -619,8 +619,8 @@ class CFProcessor(service.Service):
             CFChannel.from_channelfinder_dict(ch)
             for ch in self.client.findByArgs(
                 prepareFindArgs(
-                    self.cf_config,
-                    [
+                    cf_config=self.cf_config,
+                    args=[
                         (CFPropertyName.pvStatus.name, PVStatus.Active.name),
                         (CFPropertyName.recceiverID.name, recceiverid),
                     ],
@@ -864,7 +864,9 @@ def get_existing_channels(
 
     for each_search_string in search_strings:
         _log.debug("Find existing channels by name: %s", each_search_string)
-        for found_channel in client.findByArgs(prepareFindArgs(cf_config, [("~name", each_search_string)])):
+        for found_channel in client.findByArgs(
+            prepareFindArgs(cf_config=cf_config, args=[("~name", each_search_string)])
+        ):
             existing_channels[found_channel["name"]] = CFChannel.from_channelfinder_dict(found_channel)
         if processor.cancelled:
             raise defer.CancelledError(
@@ -1078,7 +1080,7 @@ def _update_channelfinder(
     _log.debug("Find existing channels by IOCID: %s", ioc_info)
     old_channels: List[CFChannel] = [
         CFChannel.from_channelfinder_dict(ch)
-        for ch in client.findByArgs(prepareFindArgs(cf_config, [("iocid", iocid)]))
+        for ch in client.findByArgs(prepareFindArgs(cf_config=cf_config, args=[("iocid", iocid)]))
     ]
 
     if old_channels is not None:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -88,76 +88,76 @@ class CFProperty:
         """Convert to dictionary for Channelfinder API."""
         return {"name": self.name, "owner": self.owner, "value": self.value or ""}
 
-    @staticmethod
-    def from_channelfinder_dict(prop_dict: Dict[str, str]) -> "CFProperty":
+    @classmethod
+    def from_channelfinder_dict(cls, prop_dict: Dict[str, str]) -> "CFProperty":
         """Create CFProperty from Channelfinder json output.
 
         Args:
             prop_dict: Dictionary representing a property from Channelfinder.
         """
-        return CFProperty(
+        return cls(
             name=prop_dict.get("name", ""),
             owner=prop_dict.get("owner", ""),
             value=prop_dict.get("value"),
         )
 
-    @staticmethod
-    def record_type(owner: str, record_type: str) -> "CFProperty":
+    @classmethod
+    def record_type(cls, owner: str, record_type: str) -> "CFProperty":
         """Create a Channelfinder recordType property.
 
         Args:
             owner: The owner of the property.
             recordType: The recordType of the property.
         """
-        return CFProperty(CFPropertyName.recordType.name, owner, record_type)
+        return cls(CFPropertyName.recordType.name, owner, record_type)
 
-    @staticmethod
-    def alias(owner: str, alias: str) -> "CFProperty":
+    @classmethod
+    def alias(cls, owner: str, alias: str) -> "CFProperty":
         """Create a Channelfinder alias property.
 
         Args:
             owner: The owner of the property.
             alias: The alias of the property.
         """
-        return CFProperty(CFPropertyName.alias.name, owner, alias)
+        return cls(CFPropertyName.alias.name, owner, alias)
 
-    @staticmethod
-    def pv_status(owner: str, pv_status: PVStatus) -> "CFProperty":
+    @classmethod
+    def pv_status(cls, owner: str, pv_status: PVStatus) -> "CFProperty":
         """Create a Channelfinder pvStatus property.
 
         Args:
             owner: The owner of the property.
             pvStatus: The pvStatus of the property.
         """
-        return CFProperty(CFPropertyName.pvStatus.name, owner, pv_status.name)
+        return cls(CFPropertyName.pvStatus.name, owner, pv_status.name)
 
-    @staticmethod
-    def active(owner: str) -> "CFProperty":
+    @classmethod
+    def active(cls, owner: str) -> "CFProperty":
         """Create a Channelfinder active property.
 
         Args:
             owner: The owner of the property.
         """
-        return CFProperty.pv_status(owner, PVStatus.Active)
+        return cls.pv_status(owner, PVStatus.Active)
 
-    @staticmethod
-    def inactive(owner: str) -> "CFProperty":
+    @classmethod
+    def inactive(cls, owner: str) -> "CFProperty":
         """Create a Channelfinder inactive property.
 
         Args:
             owner: The owner of the property.
         """
-        return CFProperty.pv_status(owner, PVStatus.Inactive)
+        return cls.pv_status(owner, PVStatus.Inactive)
 
-    @staticmethod
-    def time(owner: str, time: str) -> "CFProperty":
+    @classmethod
+    def time(cls, owner: str, time: str) -> "CFProperty":
         """Create a Channelfinder time property.
 
         Args:
             owner: The owner of the property.
             time: The time of the property.
         """
-        return CFProperty(CFPropertyName.time.name, owner, time)
+        return cls(CFPropertyName.time.name, owner, time)
 
 
 @dataclass

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -221,6 +221,7 @@ class CFChannel:
             "properties": [p.as_dict() for p in self.properties],
         }
 
+    @staticmethod
     def from_channelfinder_dict(channel_dict: Dict[str, Any]) -> "CFChannel":
         """Create CFChannel from Channelfinder json output.
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -468,7 +468,8 @@ class CFProcessor(service.Service):
                     )
         return record_infos
 
-    def record_info_by_name(self, record_infos: Dict[str, RecordInfo], ioc_info: IocInfo) -> Dict[str, RecordInfo]:
+    @staticmethod
+    def record_info_by_name(record_infos: Dict[str, RecordInfo], ioc_info: IocInfo) -> Dict[str, RecordInfo]:
         """Create a dictionary of RecordInfo objects keyed by pvName.
 
         Args:
@@ -564,7 +565,7 @@ class CFProcessor(service.Service):
         records_to_delete = list(transaction.records_to_delete)
         _log.debug("Delete records: %s", records_to_delete)
 
-        record_info_by_name = self.record_info_by_name(record_infos, ioc_info)
+        record_info_by_name = CFProcessor.record_info_by_name(record_infos, ioc_info)
         self.update_ioc_infos(transaction, ioc_info, records_to_delete, record_info_by_name)
         poll(_update_channelfinder, self, record_info_by_name, records_to_delete, ioc_info)
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -361,9 +361,9 @@ class CFProcessor(service.Service):
         Args:
             transaction_record: The transaction to commit.
         """
-        return self.lock.run(self._commitWithLock, transaction_record)
+        return self.lock.run(self._commit_with_lock, transaction_record)
 
-    def _commitWithLock(self, transaction: interfaces.ITransaction) -> defer.Deferred:
+    def _commit_with_lock(self, transaction: interfaces.ITransaction) -> defer.Deferred:
         """Commit a transaction to Channelfinder with lock held.
 
         Args:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -845,29 +845,29 @@ def get_existing_channels(
         cf_config: The configuration for the processor.
         processor: The processor.
     """
-    existingChannels: Dict[str, CFChannel] = {}
+    existing_channels: Dict[str, CFChannel] = {}
 
     # The list of pv's is searched keeping in mind the limitations on the URL length
-    searchStrings = []
-    searchString = ""
+    search_strings = []
+    search_string = ""
     for channel_name in new_channels:
-        if not searchString:
-            searchString = channel_name
-        elif len(searchString) + len(channel_name) < 600:
-            searchString = searchString + "|" + channel_name
+        if not search_string:
+            search_string = channel_name
+        elif len(search_string) + len(channel_name) < 600:
+            search_string = search_string + "|" + channel_name
         else:
-            searchStrings.append(searchString)
-            searchString = channel_name
-    if searchString:
-        searchStrings.append(searchString)
+            search_strings.append(search_string)
+            search_string = channel_name
+    if search_string:
+        search_strings.append(search_string)
 
-    for eachSearchString in searchStrings:
-        _log.debug("Find existing channels by name: %s", eachSearchString)
-        for found_channel in client.findByArgs(prepareFindArgs(cf_config, [("~name", eachSearchString)])):
-            existingChannels[found_channel["name"]] = CFChannel.from_channelfinder_dict(found_channel)
+    for each_search_string in search_strings:
+        _log.debug("Find existing channels by name: %s", each_search_string)
+        for found_channel in client.findByArgs(prepareFindArgs(cf_config, [("~name", each_search_string)])):
+            existing_channels[found_channel["name"]] = CFChannel.from_channelfinder_dict(found_channel)
         if processor.cancelled:
             raise defer.CancelledError()
-    return existingChannels
+    return existing_channels
 
 
 def handle_old_channels(
@@ -949,7 +949,7 @@ def handle_old_channels(
 
 
 def update_existing_channel_diff_iocid(
-    existingChannels: Dict[str, CFChannel],
+    existing_channels: Dict[str, CFChannel],
     channel_name: str,
     newProps: List[CFProperty],
     processor: CFProcessor,
@@ -965,7 +965,7 @@ def update_existing_channel_diff_iocid(
         channels
 
     Args:
-        existingChannels: The dictionary of existing channels.
+        existing_channels: The dictionary of existing channels.
         channel_name: The name of the channel.
         newProps: The new properties.
         processor: The processor.
@@ -975,14 +975,14 @@ def update_existing_channel_diff_iocid(
         ioc_info: The IOC information.
         iocid: The IOC ID.
     """
-    existingChannel = existingChannels[channel_name]
-    existingChannel.properties = __merge_property_lists(
+    existing_channel = existing_channels[channel_name]
+    existing_channel.properties = __merge_property_lists(
         newProps,
-        existingChannel,
+        existing_channel,
         processor.managed_properties,
     )
-    channels.append(existingChannel)
-    _log.debug("Add existing channel with different IOC: %s", existingChannel)
+    channels.append(existing_channel)
+    _log.debug("Add existing channel with different IOC: %s", existing_channel)
     # in case, alias exists, update their properties too
     if cf_config.alias_enabled:
         if channel_name in record_info_by_name:
@@ -990,8 +990,8 @@ def update_existing_channel_diff_iocid(
             for p in newProps:
                 alProps.append(p)
             for alias_name in record_info_by_name[channel_name].aliases:
-                if alias_name in existingChannels:
-                    ach = existingChannels[alias_name]
+                if alias_name in existing_channels:
+                    ach = existing_channels[alias_name]
                     ach.properties = __merge_property_lists(
                         alProps,
                         ach,
@@ -1094,7 +1094,7 @@ def __updateCF__(
             iocid,
         )
     # now pvNames contains a list of pv's new on this host/ioc
-    existingChannels = get_existing_channels(new_channels, client, cf_config, processor)
+    existing_channels = get_existing_channels(new_channels, client, cf_config, processor)
 
     for channel_name in new_channels:
         newProps = create_ioc_properties(
@@ -1115,10 +1115,10 @@ def __updateCF__(
         if channel_name in record_info_by_name:
             newProps = newProps + record_info_by_name[channel_name].info_properties
 
-        if channel_name in existingChannels:
+        if channel_name in existing_channels:
             _log.debug("update existing channel %s: exists but with a different iocid from %s", channel_name, iocid)
             update_existing_channel_diff_iocid(
-                existingChannels,
+                existing_channels,
                 channel_name,
                 newProps,
                 processor,

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -28,6 +28,7 @@ __all__ = ["CFProcessor"]
 
 RECCEIVERID_DEFAULT = socket.gethostname()
 DEFAULT_MAX_CHANNEL_NAME_QUERY_LENGTH = 600
+DEFAULT_QUERY_LIMIT = 10_000
 
 
 class PVStatus(enum.Enum):
@@ -52,7 +53,7 @@ class CFConfig:
     username: str = "cfstore"
     recceiver_id: str = RECCEIVERID_DEFAULT
     timezone: Optional[str] = None
-    cf_query_limit: int = 10000
+    cf_query_limit: int = DEFAULT_QUERY_LIMIT
 
     @classmethod
     def loads(cls, conf: ConfigAdapter) -> "CFConfig":
@@ -73,7 +74,7 @@ class CFConfig:
             username=conf.get("username", "cfstore"),
             recceiver_id=conf.get("recceiverId", RECCEIVERID_DEFAULT),
             timezone=conf.get("timezone", ""),
-            cf_query_limit=conf.get("findSizeLimit", 10000),
+            cf_query_limit=conf.get("findSizeLimit", DEFAULT_QUERY_LIMIT),
         )
 
 
@@ -1143,7 +1144,7 @@ def _update_channelfinder(
         raise defer.CancelledError(f"Processor cancelled in _update_channelfinder for {ioc_info}")
 
 
-def cf_set_chunked(client: ChannelFinderClient, channels: List[CFChannel], chunk_size=10000) -> None:
+def cf_set_chunked(client: ChannelFinderClient, channels: List[CFChannel], chunk_size=DEFAULT_QUERY_LIMIT) -> None:
     """Submit a list of channels to channelfinder in a chunked way.
 
     Args:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -109,7 +109,7 @@ class CFProperty:
             owner: The owner of the property.
             recordType: The recordType of the property.
         """
-        return cls(CFPropertyName.recordType.name, owner, record_type)
+        return cls(CFPropertyName.RECORD_TYPE.value, owner, record_type)
 
     @classmethod
     def alias(cls, owner: str, alias: str) -> "CFProperty":
@@ -119,7 +119,7 @@ class CFProperty:
             owner: The owner of the property.
             alias: The alias of the property.
         """
-        return cls(CFPropertyName.alias.name, owner, alias)
+        return cls(CFPropertyName.ALIAS.value, owner, alias)
 
     @classmethod
     def pv_status(cls, owner: str, pv_status: PVStatus) -> "CFProperty":
@@ -129,7 +129,7 @@ class CFProperty:
             owner: The owner of the property.
             pvStatus: The pvStatus of the property.
         """
-        return cls(CFPropertyName.pvStatus.name, owner, pv_status.value)
+        return cls(CFPropertyName.PV_STATUS.value, owner, pv_status.value)
 
     @classmethod
     def active(cls, owner: str) -> "CFProperty":
@@ -157,7 +157,7 @@ class CFProperty:
             owner: The owner of the property.
             time: The time of the property.
         """
-        return cls(CFPropertyName.time.name, owner, time)
+        return cls(CFPropertyName.TIME.value, owner, time)
 
 
 @dataclass
@@ -170,21 +170,21 @@ class RecordInfo:
     aliases: List[str] = field(default_factory=list)
 
 
-class CFPropertyName(enum.Enum):
+class CFPropertyName(enum.StrEnum):
     """Standard property names used in Channelfinder."""
 
-    hostName = enum.auto()
-    iocName = enum.auto()
-    iocid = enum.auto()
-    iocIP = enum.auto()
-    pvStatus = enum.auto()
-    time = enum.auto()
-    recceiverID = enum.auto()
-    alias = enum.auto()
-    recordType = enum.auto()
-    recordDesc = enum.auto()
-    caPort = enum.auto()
-    pvaPort = enum.auto()
+    HOSTNAME = "hostName"
+    IOC_NAME = "iocName"
+    IOC_ID = "iocid"
+    IOC_IP = "iocIP"
+    PV_STATUS = "pvStatus"
+    TIME = "time"
+    RECCEIVER_ID = "recceiverID"
+    ALIAS = "alias"
+    RECORD_TYPE = "recordType"
+    RECORD_DESC = "recordDesc"
+    CA_PORT = "caPort"
+    PVA_PORT = "pvaPort"
 
 
 @dataclass
@@ -291,19 +291,19 @@ class CFProcessor(service.Service):
             try:
                 cf_properties = {cf_property["name"] for cf_property in self.client.getAllProperties()}
                 required_properties = {
-                    CFPropertyName.hostName.name,
-                    CFPropertyName.iocName.name,
-                    CFPropertyName.iocid.name,
-                    CFPropertyName.iocIP.name,
-                    CFPropertyName.pvStatus.name,
-                    CFPropertyName.time.name,
-                    CFPropertyName.recceiverID.name,
+                    CFPropertyName.HOSTNAME.value,
+                    CFPropertyName.IOC_NAME.value,
+                    CFPropertyName.IOC_ID.value,
+                    CFPropertyName.IOC_IP.value,
+                    CFPropertyName.PV_STATUS.value,
+                    CFPropertyName.TIME.value,
+                    CFPropertyName.RECCEIVER_ID.value,
                 }
 
                 if self.cf_config.alias_enabled:
-                    required_properties.add(CFPropertyName.alias.name)
+                    required_properties.add(CFPropertyName.ALIAS.value)
                 if self.cf_config.record_type_enabled:
-                    required_properties.add(CFPropertyName.recordType.name)
+                    required_properties.add(CFPropertyName.RECORD_TYPE.value)
                 env_vars_setting = self.cf_config.environment_variables
                 self.env_vars = {}
                 if env_vars_setting != "" and env_vars_setting is not None:
@@ -317,12 +317,12 @@ class CFProcessor(service.Service):
                 if self.cf_config.ioc_connection_info:
                     self.env_vars["RSRV_SERVER_PORT"] = "caPort"
                     self.env_vars["PVAS_SERVER_PORT"] = "pvaPort"
-                    required_properties.add(CFPropertyName.caPort.name)
-                    required_properties.add(CFPropertyName.pvaPort.name)
+                    required_properties.add(CFPropertyName.CA_PORT.value)
+                    required_properties.add(CFPropertyName.PVA_PORT.value)
 
                 record_property_names_list = [s.strip(", ") for s in self.cf_config.info_tags.split()]
                 if self.cf_config.record_description_enabled:
-                    record_property_names_list.append(CFPropertyName.recordDesc.name)
+                    record_property_names_list.append(CFPropertyName.RECORD_DESC.value)
                 # Are any required properties not already present on CF?
                 properties = required_properties - cf_properties
                 # Are any whitelisted properties not already present on CF?
@@ -627,8 +627,8 @@ class CFProcessor(service.Service):
                 prepare_find_args(
                     cf_config=self.cf_config,
                     args=[
-                        (CFPropertyName.pvStatus.name, PVStatus.ACTIVE.value),
-                        (CFPropertyName.recceiverID.name, recceiverid),
+                        (CFPropertyName.PV_STATUS.value, PVStatus.ACTIVE.value),
+                        (CFPropertyName.RECCEIVER_ID.value, recceiverid),
                     ],
                 )
             )
@@ -1177,13 +1177,13 @@ def create_ioc_properties(
         iocid: The IOC ID of the properties.
     """
     return [
-        CFProperty(CFPropertyName.hostName.name, owner, hostName),
-        CFProperty(CFPropertyName.iocName.name, owner, iocName),
-        CFProperty(CFPropertyName.iocid.name, owner, iocid),
-        CFProperty(CFPropertyName.iocIP.name, owner, iocIP),
+        CFProperty(CFPropertyName.HOSTNAME.value, owner, hostName),
+        CFProperty(CFPropertyName.IOC_NAME.value, owner, iocName),
+        CFProperty(CFPropertyName.IOC_ID.value, owner, iocid),
+        CFProperty(CFPropertyName.IOC_IP.value, owner, iocIP),
         CFProperty.active(owner),
         CFProperty.time(owner, iocTime),
-        CFProperty(CFPropertyName.recceiverID.name, owner, recceiverid),
+        CFProperty(CFPropertyName.RECCEIVER_ID.value, owner, recceiverid),
     ]
 
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -30,6 +30,13 @@ RECCEIVERID_DEFAULT = socket.gethostname()
 DEFAULT_MAX_CHANNEL_NAME_QUERY_LENGTH = 600
 
 
+class PVStatus(enum.Enum):
+    """PV Status values."""
+
+    Active = enum.auto()
+    Inactive = enum.auto()
+
+
 @dataclass
 class CFConfig:
     """Configuration options for the CF Processor"""
@@ -114,14 +121,14 @@ class CFProperty:
         return CFProperty(CFPropertyName.alias.name, owner, alias)
 
     @staticmethod
-    def pvStatus(owner: str, pvStatus: str) -> "CFProperty":
+    def pv_status(owner: str, pv_status: PVStatus) -> "CFProperty":
         """Create a Channelfinder pvStatus property.
 
         Args:
             owner: The owner of the property.
             pvStatus: The pvStatus of the property.
         """
-        return CFProperty(CFPropertyName.pvStatus.name, owner, pvStatus)
+        return CFProperty(CFPropertyName.pvStatus.name, owner, pv_status.name)
 
     @staticmethod
     def active(owner: str) -> "CFProperty":
@@ -130,7 +137,7 @@ class CFProperty:
         Args:
             owner: The owner of the property.
         """
-        return CFProperty.pvStatus(owner, PVStatus.Active.name)
+        return CFProperty.pv_status(owner, PVStatus.Active)
 
     @staticmethod
     def inactive(owner: str) -> "CFProperty":
@@ -139,7 +146,7 @@ class CFProperty:
         Args:
             owner: The owner of the property.
         """
-        return CFProperty.pvStatus(owner, PVStatus.Inactive.name)
+        return CFProperty.pv_status(owner, PVStatus.Inactive)
 
     @staticmethod
     def time(owner: str, time: str) -> "CFProperty":
@@ -177,13 +184,6 @@ class CFPropertyName(enum.Enum):
     recordDesc = enum.auto()
     caPort = enum.auto()
     pvaPort = enum.auto()
-
-
-class PVStatus(enum.Enum):
-    """PV Status values."""
-
-    Active = enum.auto()
-    Inactive = enum.auto()
 
 
 @dataclass

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -89,7 +89,7 @@ class CFProperty:
         return {"name": self.name, "owner": self.owner, "value": self.value or ""}
 
     @classmethod
-    def from_channelfinder_dict(cls, prop_dict: Dict[str, str]) -> "CFProperty":
+    def from_dict(cls, prop_dict: Dict[str, str]) -> "CFProperty":
         """Create CFProperty from Channelfinder json output.
 
         Args:
@@ -223,7 +223,7 @@ class CFChannel:
         }
 
     @classmethod
-    def from_channelfinder_dict(cls, channel_dict: Dict[str, Any]) -> "CFChannel":
+    def from_dict(cls, channel_dict: Dict[str, Any]) -> "CFChannel":
         """Create CFChannel from Channelfinder json output.
 
         Args:
@@ -232,7 +232,7 @@ class CFChannel:
         return cls(
             name=channel_dict.get("name", ""),
             owner=channel_dict.get("owner", ""),
-            properties=[CFProperty.from_channelfinder_dict(p) for p in channel_dict.get("properties", [])],
+            properties=[CFProperty.from_dict(p) for p in channel_dict.get("properties", [])],
         )
 
 
@@ -622,7 +622,7 @@ class CFProcessor(service.Service):
             recceiverid: The current recceiver id.
         """
         return [
-            CFChannel.from_channelfinder_dict(ch)
+            CFChannel.from_dict(ch)
             for ch in self.client.findByArgs(
                 prepareFindArgs(
                     cf_config=self.cf_config,
@@ -872,7 +872,7 @@ def get_existing_channels(
         for found_channel in client.findByArgs(
             prepareFindArgs(cf_config=cf_config, args=[("~name", each_search_string)])
         ):
-            existing_channels[found_channel["name"]] = CFChannel.from_channelfinder_dict(found_channel)
+            existing_channels[found_channel["name"]] = CFChannel.from_dict(found_channel)
     return existing_channels
 
 
@@ -1079,7 +1079,7 @@ def _update_channelfinder(
     # A list of channels in channelfinder with the associated hostName and iocName
     _log.debug("Find existing channels by IOCID: %s", ioc_info)
     old_channels: List[CFChannel] = [
-        CFChannel.from_channelfinder_dict(ch)
+        CFChannel.from_dict(ch)
         for ch in client.findByArgs(prepareFindArgs(cf_config=cf_config, args=[("iocid", iocid)]))
     ]
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -951,7 +951,7 @@ def handle_old_channels(
 def update_existing_channel_diff_iocid(
     existing_channels: Dict[str, CFChannel],
     channel_name: str,
-    newProps: List[CFProperty],
+    new_properties: List[CFProperty],
     processor: CFProcessor,
     channels: List[CFChannel],
     cf_config: CFConfig,
@@ -967,7 +967,7 @@ def update_existing_channel_diff_iocid(
     Args:
         existing_channels: The dictionary of existing channels.
         channel_name: The name of the channel.
-        newProps: The new properties.
+        new_properties: The new properties.
         processor: The processor.
         channels: The list of channels.
         cf_config: configuration of processor
@@ -977,7 +977,7 @@ def update_existing_channel_diff_iocid(
     """
     existing_channel = existing_channels[channel_name]
     existing_channel.properties = __merge_property_lists(
-        newProps,
+        new_properties,
         existing_channel,
         processor.managed_properties,
     )
@@ -987,7 +987,7 @@ def update_existing_channel_diff_iocid(
     if cf_config.alias_enabled:
         if channel_name in record_info_by_name:
             alias_properties = [CFProperty.alias(ioc_info.owner, channel_name)]
-            for p in newProps:
+            for p in new_properties:
                 alias_properties.append(p)
             for alias_name in record_info_by_name[channel_name].aliases:
                 if alias_name in existing_channels:
@@ -1007,7 +1007,7 @@ def create_new_channel(
     channels: List[CFChannel],
     channel_name: str,
     ioc_info: IocInfo,
-    newProps: List[CFProperty],
+    new_properties: List[CFProperty],
     cf_config: CFConfig,
     record_info_by_name: Dict[str, RecordInfo],
 ) -> None:
@@ -1020,17 +1020,17 @@ def create_new_channel(
         channels: The list of channels.
         channel_name: The name of the channel.
         ioc_info: The IOC information.
-        newProps: The new properties.
+        new_properties: The new properties.
         cf_config: configuration of processor
         record_info_by_name: The dictionary of record names to information.
     """
 
-    channels.append(CFChannel(channel_name, ioc_info.owner, newProps))
+    channels.append(CFChannel(channel_name, ioc_info.owner, new_properties))
     _log.debug("Add new channel: %s", channel_name)
     if cf_config.alias_enabled:
         if channel_name in record_info_by_name:
             alias_properties = [CFProperty.alias(ioc_info.owner, channel_name)]
-            for p in newProps:
+            for p in new_properties:
                 alias_properties.append(p)
             for alias in record_info_by_name[channel_name].aliases:
                 channels.append(CFChannel(alias, ioc_info.owner, alias_properties))
@@ -1097,7 +1097,7 @@ def __updateCF__(
     existing_channels = get_existing_channels(new_channels, client, cf_config, processor)
 
     for channel_name in new_channels:
-        newProps = create_ioc_properties(
+        new_properties = create_ioc_properties(
             ioc_info.owner,
             ioc_info.time,
             recceiverid,
@@ -1111,16 +1111,16 @@ def __updateCF__(
             and channel_name in record_info_by_name
             and record_info_by_name[channel_name].record_type
         ):
-            newProps.append(CFProperty.record_type(ioc_info.owner, record_info_by_name[channel_name].record_type))
+            new_properties.append(CFProperty.record_type(ioc_info.owner, record_info_by_name[channel_name].record_type))
         if channel_name in record_info_by_name:
-            newProps = newProps + record_info_by_name[channel_name].info_properties
+            new_properties = new_properties + record_info_by_name[channel_name].info_properties
 
         if channel_name in existing_channels:
             _log.debug("update existing channel %s: exists but with a different iocid from %s", channel_name, iocid)
             update_existing_channel_diff_iocid(
                 existing_channels,
                 channel_name,
-                newProps,
+                new_properties,
                 processor,
                 channels,
                 cf_config,
@@ -1129,7 +1129,7 @@ def __updateCF__(
                 iocid,
             )
         else:
-            create_new_channel(channels, channel_name, ioc_info, newProps, cf_config, record_info_by_name)
+            create_new_channel(channels, channel_name, ioc_info, new_properties, cf_config, record_info_by_name)
     _log.info("Total channels to update: %s for ioc: %s", len(channels), ioc_info)
 
     if len(channels) != 0:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -372,7 +372,7 @@ class CFProcessor(service.Service):
         """
         self.cancelled = False
 
-        t = deferToThread(self._commitWithThread, transaction)
+        t = deferToThread(self._commit_with_thread, transaction)
 
         def cancelCommit(d: defer.Deferred):
             """Cancel the commit operation."""
@@ -518,7 +518,7 @@ class CFProcessor(service.Service):
                         for record_aliases in record_info_by_name[record_name].aliases:
                             self.remove_channel(record_aliases, iocid)
 
-    def _commitWithThread(self, transaction: CommitTransaction):
+    def _commit_with_thread(self, transaction: CommitTransaction):
         """Commit the transaction to Channelfinder.
 
         Collects the ioc info from the transaction.

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -79,6 +79,64 @@ class CFProperty:
             value=prop_dict.get("value"),
         )
 
+    @staticmethod
+    def recordType(owner: str, recordType: str) -> "CFProperty":
+        """Create a Channelfinder recordType property.
+
+        Args:
+            owner: The owner of the property.
+            recordType: The recordType of the property.
+        """
+        return CFProperty(CFPropertyName.recordType.name, owner, recordType)
+
+    @staticmethod
+    def alias(owner: str, alias: str) -> "CFProperty":
+        """Create a Channelfinder alias property.
+
+        Args:
+            owner: The owner of the property.
+            alias: The alias of the property.
+        """
+        return CFProperty(CFPropertyName.alias.name, owner, alias)
+
+    @staticmethod
+    def pvStatus(owner: str, pvStatus: str) -> "CFProperty":
+        """Create a Channelfinder pvStatus property.
+
+        Args:
+            owner: The owner of the property.
+            pvStatus: The pvStatus of the property.
+        """
+        return CFProperty(CFPropertyName.pvStatus.name, owner, pvStatus)
+
+    @staticmethod
+    def active(owner: str) -> "CFProperty":
+        """Create a Channelfinder active property.
+
+        Args:
+            owner: The owner of the property.
+        """
+        return CFProperty.pvStatus(owner, PVStatus.Active.name)
+
+    @staticmethod
+    def inactive(owner: str) -> "CFProperty":
+        """Create a Channelfinder inactive property.
+
+        Args:
+            owner: The owner of the property.
+        """
+        return CFProperty.pvStatus(owner, PVStatus.Inactive.name)
+
+    @staticmethod
+    def time(owner: str, time: str) -> "CFProperty":
+        """Create a Channelfinder time property.
+
+        Args:
+            owner: The owner of the property.
+            time: The time of the property.
+        """
+        return CFProperty(CFPropertyName.time.name, owner, time)
+
 
 @dataclass
 class RecordInfo:
@@ -470,33 +528,9 @@ class CFProcessor(service.Service):
             'Update "pvStatus" property to "Inactive" for {n_channels} channels'.format(n_channels=len(new_channels))
         )
         self.client.update(
-            property=create_inactive_property(owner).as_dict(),
+            property=CFProperty.inactive(owner).as_dict(),
             channelNames=new_channels,
         )
-
-
-def create_recordType_property(owner: str, recordType: str) -> CFProperty:
-    return CFProperty(CFPropertyName.recordType.name, owner, recordType)
-
-
-def create_alias_property(owner: str, alias: str) -> CFProperty:
-    return CFProperty(CFPropertyName.alias.name, owner, alias)
-
-
-def create_pvStatus_property(owner: str, pvStatus: str) -> CFProperty:
-    return CFProperty(CFPropertyName.pvStatus.name, owner, pvStatus)
-
-
-def create_active_property(owner: str) -> CFProperty:
-    return create_pvStatus_property(owner, PVStatus.Active.name)
-
-
-def create_inactive_property(owner: str) -> CFProperty:
-    return create_pvStatus_property(owner, PVStatus.Inactive.name)
-
-
-def create_time_property(owner: str, time: str) -> CFProperty:
-    return CFProperty(CFPropertyName.time.name, owner, time)
 
 
 def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo], records_to_delete, ioc_info: IocInfo):
@@ -551,7 +585,7 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                     if cf_config.record_type_enabled:
                         cf_channel.properties = __merge_property_lists(
                             cf_channel.properties.append(
-                                create_recordType_property(ioc_info.owner, iocs[last_ioc_id]["recordType"])
+                                CFProperty.recordType(ioc_info.owner, iocs[last_ioc_id]["recordType"])
                             ),
                             cf_channel,
                             processor.managed_properties,
@@ -581,7 +615,7 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                                     if cf_config.record_type_enabled:
                                         cf_channel.properties = __merge_property_lists(
                                             cf_channel.properties.append(
-                                                create_recordType_property(
+                                                CFProperty.recordType(
                                                     ioc_info.owner,
                                                     iocs[last_alias_ioc_id]["recordType"],
                                                 )
@@ -596,8 +630,8 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                     """Orphan the channel : mark as inactive, keep the old hostName and iocName"""
                     cf_channel.properties = __merge_property_lists(
                         [
-                            create_inactive_property(ioc_info.owner),
-                            create_time_property(ioc_info.owner, ioc_info.time),
+                            CFProperty.inactive(ioc_info.owner),
+                            CFProperty.time(ioc_info.owner, ioc_info.time),
                         ],
                         cf_channel,
                     )
@@ -610,8 +644,8 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                                 alias_channel = CFChannel(alias_name, "", [])
                                 alias_channel.properties = __merge_property_lists(
                                     [
-                                        create_inactive_property(ioc_info.owner),
-                                        create_time_property(ioc_info.owner, ioc_info.time),
+                                        CFProperty.inactive(ioc_info.owner),
+                                        CFProperty.time(ioc_info.owner, ioc_info.time),
                                     ],
                                     alias_channel,
                                 )
@@ -628,8 +662,8 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                     )
                     cf_channel.properties = __merge_property_lists(
                         [
-                            create_active_property(ioc_info.owner),
-                            create_time_property(ioc_info.owner, ioc_info.time),
+                            CFProperty.active(ioc_info.owner),
+                            CFProperty.time(ioc_info.owner, ioc_info.time),
                         ],
                         cf_channel,
                         processor.managed_properties,
@@ -647,8 +681,8 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                                     alias_channel = CFChannel(alias_name, "", [])
                                     alias_channel.properties = __merge_property_lists(
                                         [
-                                            create_active_property(ioc_info.owner),
-                                            create_time_property(ioc_info.owner, ioc_info.time),
+                                            CFProperty.active(ioc_info.owner),
+                                            CFProperty.time(ioc_info.owner, ioc_info.time),
                                         ],
                                         alias_channel,
                                         processor.managed_properties,
@@ -659,9 +693,9 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
                                     """alias exists but not part of old list"""
                                     aprops = __merge_property_lists(
                                         [
-                                            create_active_property(ioc_info.owner),
-                                            create_time_property(ioc_info.owner, ioc_info.time),
-                                            create_alias_property(
+                                            CFProperty.active(ioc_info.owner),
+                                            CFProperty.time(ioc_info.owner, ioc_info.time),
+                                            CFProperty.alias(
                                                 ioc_info.owner,
                                                 cf_channel.name,
                                             ),
@@ -721,7 +755,7 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
             and channel_name in recordInfoByName
             and recordInfoByName[channel_name].recordType
         ):
-            newProps.append(create_recordType_property(ioc_info.owner, recordInfoByName[channel_name].recordType))
+            newProps.append(CFProperty.recordType(ioc_info.owner, recordInfoByName[channel_name].recordType))
         if channel_name in recordInfoByName:
             newProps = newProps + recordInfoByName[channel_name].infoProperties
 
@@ -741,7 +775,7 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
             """in case, alias exists, update their properties too"""
             if cf_config.alias_enabled:
                 if channel_name in recordInfoByName:
-                    alProps = [create_alias_property(ioc_info.owner, channel_name)]
+                    alProps = [CFProperty.alias(ioc_info.owner, channel_name)]
                     for p in newProps:
                         alProps.append(p)
                     for alias_name in recordInfoByName[channel_name].aliases:
@@ -763,7 +797,7 @@ def __updateCF__(processor: CFProcessor, recordInfoByName: Dict[str, RecordInfo]
             _log.debug("Add new channel: {s}".format(s=channels[-1]))
             if cf_config.alias_enabled:
                 if channel_name in recordInfoByName:
-                    alProps = [create_alias_property(ioc_info.owner, channel_name)]
+                    alProps = [CFProperty.alias(ioc_info.owner, channel_name)]
                     for p in newProps:
                         alProps.append(p)
                     for alias in recordInfoByName[channel_name].aliases:
@@ -793,8 +827,8 @@ def create_properties(owner: str, iocTime: str, recceiverid: str, hostName: str,
         CFProperty(CFPropertyName.iocName.name, owner, iocName),
         CFProperty(CFPropertyName.iocid.name, owner, iocid),
         CFProperty(CFPropertyName.iocIP.name, owner, iocIP),
-        create_active_property(owner),
-        create_time_property(owner, iocTime),
+        CFProperty.active(owner),
+        CFProperty.time(owner, iocTime),
         CFProperty(CFPropertyName.recceiverID.name, owner, recceiverid),
     ]
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -624,7 +624,7 @@ class CFProcessor(service.Service):
         return [
             CFChannel.from_dict(ch)
             for ch in self.client.findByArgs(
-                prepareFindArgs(
+                prepare_find_args(
                     cf_config=self.cf_config,
                     args=[
                         (CFPropertyName.pvStatus.name, PVStatus.Active.name),
@@ -870,7 +870,7 @@ def get_existing_channels(
     for each_search_string in search_strings:
         _log.debug("Find existing channels by name: %s", each_search_string)
         for found_channel in client.findByArgs(
-            prepareFindArgs(cf_config=cf_config, args=[("~name", each_search_string)])
+            prepare_find_args(cf_config=cf_config, args=[("~name", each_search_string)])
         ):
             existing_channels[found_channel["name"]] = CFChannel.from_dict(found_channel)
     return existing_channels
@@ -1080,7 +1080,7 @@ def _update_channelfinder(
     _log.debug("Find existing channels by IOCID: %s", ioc_info)
     old_channels: List[CFChannel] = [
         CFChannel.from_dict(ch)
-        for ch in client.findByArgs(prepareFindArgs(cf_config=cf_config, args=[("iocid", iocid)]))
+        for ch in client.findByArgs(prepare_find_args(cf_config=cf_config, args=[("iocid", iocid)]))
     ]
 
     if old_channels is not None:
@@ -1213,7 +1213,7 @@ def create_default_properties(
 
 
 def __merge_property_lists(
-    newProperties: List[CFProperty], channel: CFChannel, managed_properties: Set[str] = set()
+    new_properties: List[CFProperty], channel: CFChannel, managed_properties: Set[str] = set()
 ) -> List[CFProperty]:
     """Merges two lists of properties.
 
@@ -1222,15 +1222,15 @@ def __merge_property_lists(
     new property list wins out.
 
     Args:
-        newProperties: The new properties.
+        new_properties: The new properties.
         channel: The channel.
         managed_properties: The managed properties
     """
-    newPropNames = [p.name for p in newProperties]
-    for oldProperty in channel.properties:
-        if oldProperty.name not in newPropNames and (oldProperty.name not in managed_properties):
-            newProperties = newProperties + [oldProperty]
-    return newProperties
+    new_property_names = [p.name for p in new_properties]
+    for old_property in channel.properties:
+        if old_property.name not in new_property_names and (old_property.name not in managed_properties):
+            new_properties = new_properties + [old_property]
+    return new_properties
 
 
 def get_current_time(timezone: Optional[str] = None) -> str:
@@ -1244,7 +1244,7 @@ def get_current_time(timezone: Optional[str] = None) -> str:
     return str(datetime.datetime.now())
 
 
-def prepareFindArgs(cf_config: CFConfig, args, size=0) -> List[Tuple[str, str]]:
+def prepare_find_args(cf_config: CFConfig, args, size=0) -> List[Tuple[str, str]]:
     """Prepare the find arguments.
 
     Args:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -163,9 +163,9 @@ class CFProperty:
 class RecordInfo:
     """Information about a record to be stored in Channelfinder."""
 
-    pvName: str
-    recordType: Optional[str] = None
-    infoProperties: List[CFProperty] = field(default_factory=list)
+    pv_name: str
+    record_type: Optional[str] = None
+    info_properties: List[CFProperty] = field(default_factory=list)
     aliases: List[str] = field(default_factory=list)
 
 
@@ -426,9 +426,9 @@ class CFProcessor(service.Service):
         """
         recordInfo: Dict[str, RecordInfo] = {}
         for record_id, (record_name, record_type) in transaction.records_to_add.items():
-            recordInfo[record_id] = RecordInfo(pvName=record_name, recordType=None, infoProperties=[], aliases=[])
+            recordInfo[record_id] = RecordInfo(pv_name=record_name, record_type=None, info_properties=[], aliases=[])
             if self.cf_config.record_type_enabled:
-                recordInfo[record_id].recordType = record_type
+                recordInfo[record_id].record_type = record_type
 
         for record_id, (record_infos_to_add) in transaction.record_infos_to_add.items():
             # find intersection of these sets
@@ -438,7 +438,7 @@ class CFProcessor(service.Service):
             recinfo_wl = [p for p in self.record_property_names_list if p in record_infos_to_add.keys()]
             if recinfo_wl:
                 for infotag in recinfo_wl:
-                    recordInfo[record_id].infoProperties.append(
+                    recordInfo[record_id].info_properties.append(
                         CFProperty(infotag, ioc_info.owner, record_infos_to_add[infotag])
                     )
 
@@ -451,7 +451,7 @@ class CFProcessor(service.Service):
         for record_id in recordInfo:
             for epics_env_var_name, cf_prop_name in self.env_vars.items():
                 if transaction.client_infos.get(epics_env_var_name) is not None:
-                    recordInfo[record_id].infoProperties.append(
+                    recordInfo[record_id].info_properties.append(
                         CFProperty(cf_prop_name, ioc_info.owner, transaction.client_infos.get(epics_env_var_name))
                     )
                 else:
@@ -473,10 +473,10 @@ class CFProcessor(service.Service):
         """
         recordInfoByName = {}
         for record_id, (info) in recordInfosByRecordID.items():
-            if info.pvName in recordInfoByName:
-                _log.warning("Commit contains multiple records with PV name: %s (%s)", info.pvName, ioc_info)
+            if info.pv_name in recordInfoByName:
+                _log.warning("Commit contains multiple records with PV name: %s (%s)", info.pv_name, ioc_info)
                 continue
-            recordInfoByName[info.pvName] = info
+            recordInfoByName[info.pv_name] = info
         return recordInfoByName
 
     def update_ioc_infos(
@@ -1112,11 +1112,11 @@ def __updateCF__(
         if (
             cf_config.record_type_enabled
             and channel_name in recordInfoByName
-            and recordInfoByName[channel_name].recordType
+            and recordInfoByName[channel_name].record_type
         ):
-            newProps.append(CFProperty.record_type(ioc_info.owner, recordInfoByName[channel_name].recordType))
+            newProps.append(CFProperty.record_type(ioc_info.owner, recordInfoByName[channel_name].record_type))
         if channel_name in recordInfoByName:
-            newProps = newProps + recordInfoByName[channel_name].infoProperties
+            newProps = newProps + recordInfoByName[channel_name].info_properties
 
         if channel_name in existingChannels:
             _log.debug("update existing channel %s: exists but with a different iocid from %s", channel_name, iocid)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -44,8 +44,8 @@ class CFConfig:
     timezone: str = ""
     cf_query_limit: int = 10000
 
-    @staticmethod
-    def from_config_adapter(conf: ConfigAdapter) -> "CFConfig":
+    @classmethod
+    def loads(cls, conf: ConfigAdapter) -> "CFConfig":
         return CFConfig(
             alias_enabled=conf.get("alias", False),
             record_type_enabled=conf.get("recordType", False),
@@ -206,7 +206,7 @@ class CFChannel:
 @implementer(interfaces.IProcessor)
 class CFProcessor(service.Service):
     def __init__(self, name, conf):
-        self.cf_config = CFConfig.from_config_adapter(conf)
+        self.cf_config = CFConfig.loads(conf)
         _log.info("CF_INIT %s", self.cf_config)
         self.name = name
         self.channel_ioc_ids = defaultdict(list)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -102,6 +102,11 @@ class CFPropertyName(enum.Enum):
     pvaPort = enum.auto()
 
 
+class PVStatus(enum.Enum):
+    Active = enum.auto()
+    Inactive = enum.auto()
+
+
 @implementer(interfaces.IProcessor)
 class CFProcessor(service.Service):
     def __init__(self, name, conf):
@@ -422,7 +427,8 @@ class CFProcessor(service.Service):
     def get_active_channels(self, recceiverid):
         return self.client.findByArgs(
             prepareFindArgs(
-                self.cf_config, [(CFPropertyName.pvStatus.name, "Active"), (CFPropertyName.recceiverID.name, recceiverid)]
+                self.cf_config,
+                [(CFPropertyName.pvStatus.name, PVStatus.Active.name), (CFPropertyName.recceiverID.name, recceiverid)],
             )
         )
 
@@ -461,11 +467,11 @@ def create_pvStatus_property(owner: str, pvStatus: str) -> CFProperty:
 
 
 def create_active_property(owner: str) -> CFProperty:
-    return create_pvStatus_property(owner, "Active")
+    return create_pvStatus_property(owner, PVStatus.Active.name)
 
 
 def create_inactive_property(owner: str) -> CFProperty:
-    return create_pvStatus_property(owner, "Inactive")
+    return create_pvStatus_property(owner, PVStatus.Inactive.name)
 
 
 def create_time_property(owner: str, time: str) -> CFProperty:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -111,7 +111,7 @@ class CFProcessor(service.Service):
             """
             self.client = ChannelFinderClient()
             try:
-                cf_properties = [cf_property["name"] for cf_property in self.client.getAllProperties()]
+                cf_properties = {cf_property["name"] for cf_property in self.client.getAllProperties()}
                 required_properties = {
                     "hostName",
                     "iocName",
@@ -146,14 +146,14 @@ class CFProcessor(service.Service):
                 if self.cf_config.record_description_enabled:
                     record_property_names_list.append("recordDesc")
                 # Are any required properties not already present on CF?
-                properties = required_properties - set(cf_properties)
+                properties = required_properties - cf_properties
                 # Are any whitelisted properties not already present on CF?
                 # If so, add them too.
-                properties.update(set(record_property_names_list) - set(cf_properties))
+                properties.update(set(record_property_names_list) - cf_properties)
 
                 owner = self.cf_config.username
-                for cf_property in properties:
-                    self.client.set(property={"name": cf_property, "owner": owner})
+                for cf_property_name in properties:
+                    self.client.set(property={"name": cf_property_name, "owner": owner})
 
                 self.record_property_names_list = set(record_property_names_list)
                 self.managed_properties = required_properties.union(record_property_names_list)

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -919,7 +919,7 @@ def handle_channels(
     """
     for cf_channel in old_channels:
         if (
-            len(new_channels) == 0 or cf_channel.name in records_to_delete
+            not new_channels or cf_channel.name in records_to_delete
         ):  # case: empty commit/del, remove all reference to ioc
             _log.debug("Channel %s exists in Channelfinder not in new_channels", cf_channel)
             if cf_channel.name in channel_ioc_ids:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -873,7 +873,7 @@ def get_existing_channels(
     return existing_channels
 
 
-def handle_old_channels(
+def handle_channels(
     old_channels: List[CFChannel],
     new_channels: Set[str],
     records_to_delete: List[str],
@@ -1082,7 +1082,7 @@ def _update_channelfinder(
     ]
 
     if old_channels is not None:
-        handle_old_channels(
+        handle_channels(
             old_channels,
             new_channels,
             records_to_delete,

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -252,7 +252,7 @@ class CFProcessor(service.Service):
         self.channel_ioc_ids: Dict[str, List[str]] = defaultdict(list)
         self.iocs: Dict[str, IocInfo] = dict()
         self.client: Optional[ChannelFinderClient] = None
-        self.currentTime: Callable[[Optional[str]], str] = getCurrentTime
+        self.current_time: Callable[[Optional[str]], str] = get_current_time
         self.lock: DeferredLock = DeferredLock()
 
     def startService(self):
@@ -552,7 +552,7 @@ class CFProcessor(service.Service):
                 or transaction.client_infos.get("CF_USERNAME")
                 or self.cf_config.username
             ),
-            time=self.currentTime(self.cf_config.timezone),
+            time=self.current_time(self.cf_config.timezone),
             port=transaction.source_address.port,
             channelcount=0,
         )
@@ -1229,7 +1229,7 @@ def __merge_property_lists(
     return newProperties
 
 
-def getCurrentTime(timezone: Optional[str] = None) -> str:
+def get_current_time(timezone: Optional[str] = None) -> str:
     """Get the current time.
 
     Args:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -885,7 +885,7 @@ def poll(
     ioc_info: IocInfo,
 ):
     _log.info("Polling {iocName} begins...".format(iocName=ioc_info.ioc_name))
-    sleep = 1
+    sleep = 1.0
     success = False
     while not success:
         try:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -31,11 +31,11 @@ DEFAULT_MAX_CHANNEL_NAME_QUERY_LENGTH = 600
 DEFAULT_QUERY_LIMIT = 10_000
 
 
-class PVStatus(enum.Enum):
+class PVStatus(enum.StrEnum):
     """PV Status values."""
 
-    Active = enum.auto()
-    Inactive = enum.auto()
+    ACTIVE = "Active"
+    INACTIVE = "Inactive"
 
 
 @dataclass
@@ -129,7 +129,7 @@ class CFProperty:
             owner: The owner of the property.
             pvStatus: The pvStatus of the property.
         """
-        return cls(CFPropertyName.pvStatus.name, owner, pv_status.name)
+        return cls(CFPropertyName.pvStatus.name, owner, pv_status.value)
 
     @classmethod
     def active(cls, owner: str) -> "CFProperty":
@@ -138,7 +138,7 @@ class CFProperty:
         Args:
             owner: The owner of the property.
         """
-        return cls.pv_status(owner, PVStatus.Active)
+        return cls.pv_status(owner, PVStatus.ACTIVE)
 
     @classmethod
     def inactive(cls, owner: str) -> "CFProperty":
@@ -147,7 +147,7 @@ class CFProperty:
         Args:
             owner: The owner of the property.
         """
-        return cls.pv_status(owner, PVStatus.Inactive)
+        return cls.pv_status(owner, PVStatus.INACTIVE)
 
     @classmethod
     def time(cls, owner: str, time: str) -> "CFProperty":
@@ -627,7 +627,7 @@ class CFProcessor(service.Service):
                 prepare_find_args(
                     cf_config=self.cf_config,
                     args=[
-                        (CFPropertyName.pvStatus.name, PVStatus.Active.name),
+                        (CFPropertyName.pvStatus.name, PVStatus.ACTIVE.value),
                         (CFPropertyName.recceiverID.name, recceiverid),
                     ],
                 )

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -320,20 +320,20 @@ class CFProcessor(service.Service):
                     required_properties.add(CFPropertyName.CA_PORT.value)
                     required_properties.add(CFPropertyName.PVA_PORT.value)
 
-                record_property_names_list = [s.strip(", ") for s in self.cf_config.info_tags.split()]
+                record_property_names_list = {s.strip(", ") for s in self.cf_config.info_tags.split()}
                 if self.cf_config.record_description_enabled:
-                    record_property_names_list.append(CFPropertyName.RECORD_DESC.value)
+                    record_property_names_list.add(CFPropertyName.RECORD_DESC.value)
                 # Are any required properties not already present on CF?
                 properties = required_properties - cf_properties
                 # Are any whitelisted properties not already present on CF?
                 # If so, add them too.
-                properties.update(set(record_property_names_list) - cf_properties)
+                properties.update(record_property_names_list - cf_properties)
 
                 owner = self.cf_config.username
                 for cf_property_name in properties:
                     self.client.set(property={"name": cf_property_name, "owner": owner})
 
-                self.record_property_names_list = set(record_property_names_list)
+                self.record_property_names_list = record_property_names_list
                 self.managed_properties = required_properties.union(record_property_names_list)
                 _log.debug("record_property_names_list = %s", self.record_property_names_list)
             except ConnectionError:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -560,7 +560,7 @@ class CFProcessor(service.Service):
 
         record_info_by_name = self.record_info_by_name(record_infos, ioc_info)
         self.update_ioc_infos(transaction, ioc_info, records_to_delete, record_info_by_name)
-        poll(__updateCF__, self, record_info_by_name, records_to_delete, ioc_info)
+        poll(_updateCF, self, record_info_by_name, records_to_delete, ioc_info)
 
     def remove_channel(self, recordName: str, iocid: str) -> None:
         """Remove channel from self.iocs and self.channel_ioc_ids.
@@ -1037,7 +1037,7 @@ def create_new_channel(
                 _log.debug("Add new alias: %s from %s", alias, channel_name)
 
 
-def __updateCF__(
+def _updateCF(
     processor: CFProcessor, record_info_by_name: Dict[str, RecordInfo], records_to_delete, ioc_info: IocInfo
 ) -> None:
     """Update Channelfinder with the provided IOC and Record information.
@@ -1068,7 +1068,7 @@ def __updateCF__(
         raise Exception(f"Missing hostName {ioc_info.hostname} or iocName {ioc_info.ioc_name}")
 
     if processor.cancelled:
-        raise defer.CancelledError("Processor cancelled in __updateCF__")
+        raise defer.CancelledError(f"Processor cancelled in __updateCF__ for {ioc_info}")
 
     channels: List[CFChannel] = []
     # A list of channels in channelfinder with the associated hostName and iocName
@@ -1138,7 +1138,7 @@ def __updateCF__(
         if old_channels and len(old_channels) != 0:
             cf_set_chunked(client, channels, cf_config.cf_query_limit)
     if processor.cancelled:
-        raise defer.CancelledError()
+        raise defer.CancelledError(f"Processor cancelled in __updateCF__ for {ioc_info}")
 
 
 def cf_set_chunked(client: ChannelFinderClient, channels: List[CFChannel], chunk_size=10000) -> None:

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -94,14 +94,14 @@ class CFProperty:
         )
 
     @staticmethod
-    def recordType(owner: str, recordType: str) -> "CFProperty":
+    def record_type(owner: str, record_type: str) -> "CFProperty":
         """Create a Channelfinder recordType property.
 
         Args:
             owner: The owner of the property.
             recordType: The recordType of the property.
         """
-        return CFProperty(CFPropertyName.recordType.name, owner, recordType)
+        return CFProperty(CFPropertyName.recordType.name, owner, record_type)
 
     @staticmethod
     def alias(owner: str, alias: str) -> "CFProperty":
@@ -1114,7 +1114,7 @@ def __updateCF__(
             and channel_name in recordInfoByName
             and recordInfoByName[channel_name].recordType
         ):
-            newProps.append(CFProperty.recordType(ioc_info.owner, recordInfoByName[channel_name].recordType))
+            newProps.append(CFProperty.record_type(ioc_info.owner, recordInfoByName[channel_name].recordType))
         if channel_name in recordInfoByName:
             newProps = newProps + recordInfoByName[channel_name].infoProperties
 

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -249,7 +249,7 @@ class CFProcessor(service.Service):
         """
         self.cf_config = CFConfig.loads(conf)
         _log.info("CF_INIT %s", self.cf_config)
-        self.name = name
+        self.name = name  # Override name from service.Service
         self.channel_ioc_ids: Dict[str, List[str]] = defaultdict(list)
         self.iocs: Dict[str, IocInfo] = dict()
         self.client: Optional[ChannelFinderClient] = None
@@ -257,7 +257,10 @@ class CFProcessor(service.Service):
         self.lock: DeferredLock = DeferredLock()
 
     def startService(self):
-        """Start the CFProcessor service."""
+        """Start the CFProcessor service.
+
+        Overridden method of service.Service.startService()
+        """
         service.Service.startService(self)
         # Returning a Deferred is not supported by startService(),
         # so instead attempt to acquire the lock synchonously!
@@ -341,7 +344,10 @@ class CFProcessor(service.Service):
                     self.clean_service()
 
     def stopService(self):
-        """Stop the CFProcessor service."""
+        """Stop the CFProcessor service.
+
+        Overridden method of service.Service.stopService()
+        """
         _log.info("CF_STOP")
         service.Service.stopService(self)
         return self.lock.run(self._stop_service_with_lock)

--- a/server/recceiver/interfaces.py
+++ b/server/recceiver/interfaces.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
 
+from dataclasses import dataclass
+from typing import Dict, List, Set, Tuple
+
 from zope.interface import Attribute, Interface
 
 from twisted.application import service
@@ -19,6 +22,24 @@ class ITransaction(Interface):
     record_infos_to_add = Attribute("""Additional infos being added to existing records
     recid: {'key':'val'}
     """)
+
+
+@dataclass
+class SourceAddress:
+    host: str
+    port: int
+
+
+@dataclass
+class CommitTransaction:
+    source_address: SourceAddress
+    client_infos: Dict[str, str]
+    records_to_add: Dict[str, Tuple[str, str]]
+    records_to_delete: Set[str]
+    record_infos_to_add: Dict[str, Dict[str, str]]
+    aliases: Dict[str, List[str]]
+    initial: bool
+    connected: bool
 
 
 class IProcessor(service.IService):

--- a/server/recceiver_full.conf
+++ b/server/recceiver_full.conf
@@ -62,7 +62,7 @@ idkey = 42
 # cf-store application
 
 # A space-separated list of infotags to set as CF Properties
-infotags = archive
+infotags = archive, archiver
 
 # Feature to add CA/PVA port info for name server to channelfinder
 iocConnectionInfo = True


### PR DESCRIPTION
Large refactor of cfstore

- Adds dataclasses to handle all the intemediary types rather than the usage of dictionaries for everything.
- Swaps to snake case (where not using Twisted stuff)
- Adds typing everywhere I can
- Adds pydoc to every method
- Splits up the bigger methods to be much smaller
- Adds the full data structures to the log messages
- Cleans up exception messages to include more debug information