### PR TITLE
Update docs for info tag config

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -66,7 +66,7 @@
 [cf]
 # cf-store application
 # a space-separated list of infotags to set as CF Properties
-#infotags = archive, foo, bar, blah
+#infotags = archive foo bar blah
 
 # Uncomment line below to turn off the feature to add CA/PVA port info for name server to channelfinder
 #iocConnectionInfo = False

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -320,6 +320,7 @@ class CFProcessor(service.Service):
                     required_properties.add(CFPropertyName.CA_PORT.value)
                     required_properties.add(CFPropertyName.PVA_PORT.value)
 
+                # Space or comma and space separated strings
                 record_property_names_list = {s.strip(", ") for s in self.cf_config.info_tags.split()}
                 if self.cf_config.record_description_enabled:
                     record_property_names_list.add(CFPropertyName.RECORD_DESC.value)

--- a/server/recceiver_full.conf
+++ b/server/recceiver_full.conf
@@ -62,7 +62,7 @@ idkey = 42
 # cf-store application
 
 # A space-separated list of infotags to set as CF Properties
-infotags = archive, archiver
+infotags = archive archiver
 
 # Feature to add CA/PVA port info for name server to channelfinder
 iocConnectionInfo = True


### PR DESCRIPTION
Space separated or comma with space separated info tags are allowed. Makes all the examples follow space separated.
Gives a comment in the reading code to make clear what is expected.

Addresses comment https://github.com/ChannelFinder/recsync/pull/124/files/f74749eb22ba3c1f833fb382dbd903f3f8c7b865#r2600345657