### PR TITLE
Add an env_owner_variable

### DIFF
--- a/server/demo.conf
+++ b/server/demo.conf
@@ -102,3 +102,9 @@
 
 # Specify the timezone in the time output
 #timezone = True
+
+# The username to use when creating channels in channelfinder
+#username = cfstore
+
+# The env variable to use for the owner field when creating channels in channelfinder
+#env_owner_variable = ENGINEER

--- a/server/recceiver/cfstore.py
+++ b/server/recceiver/cfstore.py
@@ -50,6 +50,7 @@ class CFConfig:
     clean_on_start: bool = True
     clean_on_stop: bool = True
     username: str = "cfstore"
+    env_owner_variable: str = "ENGINEER"
     recceiver_id: str = RECCEIVERID_DEFAULT
     timezone: Optional[str] = None
     cf_query_limit: int = DEFAULT_QUERY_LIMIT
@@ -552,7 +553,7 @@ class CFProcessor(service.Service):
             ioc_name=transaction.client_infos.get("IOCNAME") or str(transaction.source_address.port),
             ioc_IP=transaction.source_address.host,
             owner=(
-                transaction.client_infos.get("ENGINEER")
+                transaction.client_infos.get(self.cf_config.env_owner_variable)
                 or transaction.client_infos.get("CF_USERNAME")
                 or self.cf_config.username
             ),

--- a/server/recceiver_full.conf
+++ b/server/recceiver_full.conf
@@ -98,6 +98,12 @@ environment_vars=ENGINEER:Engineer,EPICS_BASE:EpicsVersion,PWD:WorkingDirectory
 # Specify the timezone in the time output
 timezone = True
 
+# The username to use when creating channels in channelfinder
+username = cfstore
+
+# The env variable to use for the owner field when creating channels in channelfinder
+env_owner_variable = ENGINEER
+
 # The channelFinder client is configuration information is
 # stored in /etc/channelfinderapi.conf as described in the client
 # Can be configured to be this file, like so:


### PR DESCRIPTION
This allows to use specific env variable name for the owner in channelfinder.