### PR TITLE
fix: extended UDP broadcast to reach physical devices outside the virtual Docker network

### DIFF
--- a/server/compose.yml
+++ b/server/compose.yml
@@ -8,7 +8,7 @@ services:
         condition: service_healthy
         restart: true
     healthcheck:
-      test: netstat | grep cf
+      test: curl -s -f http://localhost:8080/ChannelFinder
       interval: 10s
       timeout: 30s
       retries: 3
@@ -23,16 +23,14 @@ services:
       RECCEIVER_CF_USERNAME: admin
       RECCEIVER_CF_CFUSERNAME: admin
       RECCEIVER_CF_CFPASSWORD: password
-      RECCEIVER_CF_BASEURL: http://cf:8080/ChannelFinder
+      RECCEIVER_CF_BASEURL: http://localhost:8080/ChannelFinder
       RECCEIVER_CF_VERIFYSSL: FALSE
     volumes:
       - type: bind
         source: docker/config/cf.conf
         target: /home/recceiver/channelfinderapi.conf
         read_only: true
-    networks:
-      - net-1-recc-1
-      - net-2-cf
+    network_mode: host
 
 networks:
   net-1-recc-1:

--- a/server/docker/cf-compose.yml
+++ b/server/docker/cf-compose.yml
@@ -6,7 +6,7 @@ services:
     networks:
       - net-2-cf
     ports:
-      - "8080"
+      - "8080:8080"
     depends_on:
       elasticsearch:
         condition: service_healthy


### PR DESCRIPTION
# Issue
I installed the RecCeiver service as follows:

```bash
mkdir -p $HOME/EPICS/docker/RecCeiver
cd $HOME/EPICS/docker/RecCeiver
git clone https://github.com/ChannelFinder/recsync.git
cd recsync/server
docker compose up -d
```

But with the current Docker `compose.yml` implementation, the UDP broadcast is **confined to the virtual Docker network** and only find IOCs within it. 

# Fix
If this is not the intended standard behavior of your Docker compose,  I want to offer a few minor changes, I used in our setup. 

Otherwise, just keep up with your project, really like it :v:  
