### PR TITLE
Improve CI output

### DIFF
--- a/.github/workflows/ci-scripts-build.yml
+++ b/.github/workflows/ci-scripts-build.yml
@@ -40,7 +40,7 @@ jobs:
         cmp: [gcc, clang]
         configuration: [default, static, debug, static-debug]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Prepare and compile dependencies
@@ -68,7 +68,7 @@ jobs:
         cmp: [clang]
         configuration: [default, debug]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Prepare and compile dependencies
@@ -96,7 +96,7 @@ jobs:
         cmp: [gcc, vs2022]
         configuration: [default, static, debug, static-debug]
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Prepare and compile dependencies
@@ -140,7 +140,7 @@ jobs:
         - cross: RTEMS-pc386-qemu@4.10
           test: NO
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         submodules: true
     - name: Prepare and compile dependencies

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -22,7 +22,7 @@ jobs:
         run:
             working-directory: ./server
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Log in to the Container registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -10,6 +10,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+      - uses: actions/setup-python@v6
       - uses: pre-commit/action@v3.0.0

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -64,4 +64,12 @@ jobs:
         python -m pip install .
     - name: Test with pytest
       run: |
-        pytest --log-cli-level=DEBUG
+        set -o pipefail
+        pytest -v 2>&1 | tee pytest-output.log
+    - name: Upload test log
+      if: always()
+      uses: actions/upload-artifact@v4
+      with:
+        name: pytest-log
+        path: server/pytest-output.log
+        retention-days: 14

--- a/.github/workflows/server.yml
+++ b/.github/workflows/server.yml
@@ -33,10 +33,10 @@ jobs:
         run:
             working-directory: server
     steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
         - name: Set up Python ${{ matrix.python-version }}
           if: ${{ !matrix.container }}
-          uses: actions/setup-python@v5
+          uses: actions/setup-python@v6
           with:
             python-version: ${{ matrix.python-version }}
         - name: Install
@@ -52,9 +52,9 @@ jobs:
         run:
             working-directory: server
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Set up Python
-      uses: actions/setup-python@v5
+      uses: actions/setup-python@v6
       with:
         python-version: 3.9
     - name: Install dependencies

--- a/server/pyproject.toml
+++ b/server/pyproject.toml
@@ -40,6 +40,12 @@ include-package-data = true
 [tool.setuptools.package-data]
 twisted = [ "plugins/recceiver_plugin.py" ]
 
+[tool.pytest.ini_options]
+log_level = "DEBUG"
+filterwarnings = [
+    "ignore::DeprecationWarning:testcontainers",
+]
+
 [tool.ruff]
 target-version = "py39"
 


### PR DESCRIPTION
The test job is currently incredibly noisy due to the global `--log-cli-level=DEBUG`. This makes it difficult to even spot the status.

This PR instead makes it so that verbose logs are only displayed on failure, while passing jobs will be easier to spot. The full log is also uploaded as a downloadable artifact on every run.

Also bumps actions/checkout and actions/setup-python to v6 (Node.js 24) and suppresses a testcontainers-internal deprecation warning.