### PR TITLE
fix: use getint() for findSizeLimit to prevent TypeError

### DIFF
--- a/server/recceiver/cf/config.py
+++ b/server/recceiver/cf/config.py
@@ -49,7 +49,7 @@ class CFConfig:
             env_owner_variable=conf.get("envOwnerVariable", "ENGINEER"),
             recceiver_id=conf.get("recceiverId", RECCEIVERID_DEFAULT),
             timezone=conf.get("timezone", ""),
-            cf_query_limit=conf.get("findSizeLimit", DEFAULT_QUERY_LIMIT),
+            cf_query_limit=conf.getint("findSizeLimit", DEFAULT_QUERY_LIMIT),
             base_url=conf.get("baseUrl"),
             cf_username=conf.get("cfUsername"),
             cf_password=conf.get("cfPassword"),


### PR DESCRIPTION
This MR fixes a runtime TypeError in the ChannelFinder store (cfstore) caused by configuration values being interpreted as strings instead of integers.

ERROR:recceiver.cfstore CF_COMMIT FAILURE: [Failure instance: Traceback: <class 'TypeError'>: 'str' object cannot be interpreted as an integer
	/usr/lib/python3/dist-packages/twisted/python/threadpool.py:269:inContext
	/usr/lib/python3/dist-packages/twisted/python/threadpool.py:285:<lambda>
	/usr/lib/python3/dist-packages/twisted/python/context.py:117:callWithContext
	/usr/lib/python3/dist-packages/twisted/python/context.py:82:callWithContext
	/usr/lib/python3/dist-packages/recceiver/cfstore.py:583:_commit_with_thread
	/usr/lib/python3/dist-packages/recceiver/cfstore.py:1307:poll
	/usr/lib/python3/dist-packages/recceiver/cfstore.py:1169:_update_channelfinder
	/usr/lib/python3/dist-packages/recceiver/cfstore.py:1185:cf_set_chunked
	]