### PR TITLE
fix(tests): correct the IOC dbd path

### DIFF
--- a/server/tests/integration/resources/ioc/st.cmd
+++ b/server/tests/integration/resources/ioc/st.cmd
@@ -1,5 +1,5 @@
 ## Register all support components
-dbLoadDatabase("/recsync/dbd/demo.dbd",0,0)
+dbLoadDatabase("/reccaster/dbd/demo.dbd",0,0)
 demo_registerRecordDeviceDriver(pdbbase)
 
 var(reccastTimeout, 5.0)


### PR DESCRIPTION
The integration IOC failed to start against the current `ghcr.io/channelfinder/reccaster:master` image: `dbLoadDatabase` could not open `/recsync/dbd/demo.dbd`, so no record types were registered and `iocInit` aborted with a bad DBD. Every integration test then waited out its sync timeout against an IOC that never cast.

Reccaster renamed its image build paths from `/recsync` to `/reccaster` after the repository split, and the `:master` tag was rebuilt on 2026-08-03. Since that tag moves, CI broke without any change here.